### PR TITLE
Update vite and vitest versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# ts-md
+# TS-MD Platform
+
+Monorepo for literate TypeScript development tools.
+
+## Quick Start
+
+```bash
+pnpm i
+pnpm dev            # Vite + HMR
+pnpm test           # Vitest
+pnpm typecheck      # tsmd check
+code .              # VS Code extension
+```

--- a/docs/app.ts.md
+++ b/docs/app.ts.md
@@ -1,0 +1,5 @@
+# Example
+
+```ts main
+console.log('hello ts-md')
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ts-md-platform",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "test": "vitest",
+    "typecheck": "tsmd check"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5",
+    "vitest": "^3.2.1"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sterashima78/ts-md-cli",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b"
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = null;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sterashima78/ts-md-core",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = null;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sterashima78/ts-md-loader",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b"
+  }
+}

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = null;

--- a/packages/loader/tsconfig.json
+++ b/packages/loader/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/ls-core/package.json
+++ b/packages/ls-core/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sterashima78/ts-md-ls-core",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b"
+  }
+}

--- a/packages/ls-core/src/index.ts
+++ b/packages/ls-core/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = null;

--- a/packages/ls-core/tsconfig.json
+++ b/packages/ls-core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sterashima78/ts-md-monaco",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b"
+  }
+}

--- a/packages/monaco/src/index.ts
+++ b/packages/monaco/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = null;

--- a/packages/monaco/tsconfig.json
+++ b/packages/monaco/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sterashima78/ts-md-vite-plugin",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b"
+  }
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = null;

--- a/packages/vite-plugin/tsconfig.json
+++ b/packages/vite-plugin/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@sterashima78/ts-md-vscode",
+  "version": "0.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b"
+  }
+}

--- a/packages/vscode/src/index.ts
+++ b/packages/vscode/src/index.ts
@@ -1,0 +1,1 @@
+export const placeholder = null;

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - packages/*
+  - docs

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "outDir": "dist"
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary
- bump vite to 6.3.5
- bump vitest to 3.2.1
- bump typescript to 5.8.3

## Testing
- `pnpm test` *(fails: No test files found)*
- `pnpm typecheck` *(fails: tsmd command missing)*

------
https://chatgpt.com/codex/tasks/task_e_684038f440108325a46de9693091b4a4