### PR TITLE
Implement ts-md-core with Japanese comments and tests

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,93 @@
-export const placeholder = null;
+import fs from 'fs'
+import path from 'path'
+
+export interface Chunk {
+  code: string
+  start: number
+  file: string
+  name: string
+}
+
+export type ChunkDictionary = Record<string, Chunk>
+
+/**
+ * Markdown から TypeScript のコードチャンクを抽出する
+ */
+export function parseChunks(md: string, uri: string): ChunkDictionary {
+  const lines = md.split(/\r?\n/)
+  const chunks: ChunkDictionary = {}
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const m = line.match(/^```ts\s+(\S+)/)
+    if (m) {
+      const name = m[1]
+      const start = i + 2
+      const codeLines: string[] = []
+      i++
+      while (i < lines.length && lines[i] !== '```') {
+        codeLines.push(lines[i])
+        i++
+      }
+      chunks[name] = { code: codeLines.join('\n'), start, file: uri, name }
+    }
+  }
+  return chunks
+}
+
+export interface ImportInfo {
+  file: string
+  name: string
+}
+
+/**
+ * チャンクインポート "#path:name" を importer からの相対パスで解決する
+ */
+export function resolveImport(id: string, importer: string): ImportInfo | null {
+  if (!id.startsWith('#')) return null
+  const body = id.slice(1)
+  const idx = body.lastIndexOf(':')
+  if (idx === -1) return null
+  const filePart = body.slice(0, idx)
+  const name = body.slice(idx + 1)
+  const importerDir = path.dirname(importer)
+  const file = path.resolve(importerDir, filePart)
+  return { file, name }
+}
+
+/**
+ * エントリ Markdown ファイルから再帰的に仮想ファイルを収集する
+ */
+export function collectVirtualFiles(entry: string): Record<string, Chunk> {
+  const result: Record<string, Chunk> = {}
+  const visited = new Set<string>()
+  const stack = new Set<string>()
+
+  function dfs(file: string) {
+    if (stack.has(file)) {
+      throw new Error(`circular dependency detected: ${file}`)
+    }
+    if (visited.has(file)) return
+    stack.add(file)
+    const md = fs.readFileSync(file, 'utf8')
+    const chunks = parseChunks(md, file)
+    for (const chunk of Object.values(chunks)) {
+      result[`${chunk.file}:${chunk.name}`] = chunk
+    }
+    visited.add(file)
+    for (const chunk of Object.values(chunks)) {
+      const importRegex = /import\s+['"](#.+?)['"]/g
+      let match: RegExpExecArray | null
+      while ((match = importRegex.exec(chunk.code))) {
+        const info = resolveImport(match[1], file)
+        if (info) {
+          const depFile = info.file
+          dfs(depFile)
+        }
+      }
+    }
+    stack.delete(file)
+  }
+
+  dfs(path.resolve(entry))
+  return result
+}

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -1,0 +1,77 @@
+import { parseChunks, resolveImport, collectVirtualFiles } from '../src';
+import path from 'path'
+import fs from 'fs'
+
+describe('parseChunks のテスト', () => {
+  const md = [
+    '# Example',
+    '',
+    '```ts foo',
+    "console.log('foo')",
+    '```',
+    '',
+    '```ts bar',
+    'import "#./dep.ts.md:dep"',
+    '```',
+  ].join('\n')
+
+  const chunks = parseChunks(md, '/test/example.ts.md')
+  it('チャンクを抽出できる', () => {
+    expect(Object.keys(chunks)).toEqual(['foo', 'bar'])
+    expect(chunks.foo.code.trim()).toBe("console.log('foo')")
+    expect(chunks.foo.start).toBe(4)
+  })
+})
+
+describe('resolveImport のテスト', () => {
+  it('インポート元からの相対パスを解決できる', () => {
+    const info = resolveImport('#../dep.ts.md:main', '/a/b/src/app.ts.md')!
+    expect(info.file).toBe(path.resolve('/a/b/src', '../dep.ts.md'))
+    expect(info.name).toBe('main')
+  })
+})
+
+describe('collectVirtualFiles のテスト', () => {
+  const dir = path.join(__dirname, 'fixtures')
+  const mainPath = path.join(dir, 'main.ts.md')
+
+  beforeAll(() => {
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'dep.ts.md'), [
+      '# Dep',
+      '',
+      '```ts dep',
+      "export const msg = 'dep'",
+      '```',
+    ].join('\n'))
+    fs.writeFileSync(mainPath, [
+      '# Main',
+      '',
+      '```ts main',
+      'import "#./dep.ts.md:dep"',
+      'console.log(msg)',
+      '```',
+    ].join('\n'))
+  })
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('再帰的にチャンクを収集できる', () => {
+    const files = collectVirtualFiles(mainPath)
+    const keys = Object.keys(files)
+    expect(keys).toContain(path.resolve(mainPath) + ':main')
+    expect(keys).toContain(path.resolve(dir, 'dep.ts.md') + ':dep')
+  })
+
+  it('循環参照を検出できる', () => {
+    const cyclePath = path.join(dir, 'cycle.ts.md')
+    fs.writeFileSync(cyclePath, [
+      '```ts a',
+      'import "#./cycle.ts.md:a"',
+      '```',
+    ].join('\n'))
+    expect(() => collectVirtualFiles(cyclePath)).toThrow('circular')
+  })
+})


### PR DESCRIPTION
## Summary
- translate comments in `ts-md-core` to Japanese
- rename test titles to Japanese

## Testing
- `pnpm test`
- `pnpm typecheck` *(fails: tsmd not found)*

------
https://chatgpt.com/codex/tasks/task_e_684040f18ce08325baf1c0a6f6c1546f