### PR TITLE
Add typecheck and tests to CI

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  biome:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,3 +17,7 @@ jobs:
         run: pnpm i --frozen-lockfile
       - name: Run Biome Check
         run: npx -y @biomejs/biome check .
+      - name: Run Type Check
+        run: pnpm typecheck
+      - name: Run Tests
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.7.0",
+    "@types/node": "^22.15.29",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
     "vitest": "^3.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,15 +11,18 @@ importers:
       '@biomejs/biome':
         specifier: ^1.7.0
         version: 1.9.4
+      '@types/node':
+        specifier: ^22.15.29
+        version: 22.15.29
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5
+        version: 6.3.5(@types/node@22.15.29)
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1
+        version: 3.2.1(@types/node@22.15.29)
 
   packages/cli: {}
 
@@ -352,6 +355,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/node@22.15.29':
+    resolution: {integrity: sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==}
+
   '@vitest/expect@3.2.1':
     resolution: {integrity: sha512-FqS/BnDOzV6+IpxrTg5GQRyLOCtcJqkwMwcS8qGCI2IyRVDwPAtutztaf1CjtPHlZlWtl1yUPCd7HM0cNiDOYw==}
 
@@ -514,6 +520,9 @@ packages:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   vite-node@3.2.1:
     resolution: {integrity: sha512-V4EyKQPxquurNJPtQJRZo8hKOoKNBRIhxcDbQFPFig0JdoWcUhwRgK8yoCXXrfYVPKS6XwirGHPszLnR8FbjCA==}
@@ -775,6 +784,10 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
+  '@types/node@22.15.29':
+    dependencies:
+      undici-types: 6.21.0
+
   '@vitest/expect@3.2.1':
     dependencies:
       '@types/chai': 5.2.2
@@ -783,13 +796,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.1(vite@6.3.5)':
+  '@vitest/mocker@3.2.1(vite@6.3.5(@types/node@22.15.29))':
     dependencies:
       '@vitest/spy': 3.2.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5
+      vite: 6.3.5(@types/node@22.15.29)
 
   '@vitest/pretty-format@3.2.1':
     dependencies:
@@ -954,13 +967,15 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  vite-node@3.2.1:
+  undici-types@6.21.0: {}
+
+  vite-node@3.2.1(@types/node@22.15.29):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5
+      vite: 6.3.5(@types/node@22.15.29)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -975,7 +990,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5:
+  vite@6.3.5(@types/node@22.15.29):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.5(picomatch@4.0.2)
@@ -984,13 +999,14 @@ snapshots:
       rollup: 4.41.1
       tinyglobby: 0.2.14
     optionalDependencies:
+      '@types/node': 22.15.29
       fsevents: 2.3.3
 
-  vitest@3.2.1:
+  vitest@3.2.1(@types/node@22.15.29):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.1
-      '@vitest/mocker': 3.2.1(vite@6.3.5)
+      '@vitest/mocker': 3.2.1(vite@6.3.5(@types/node@22.15.29))
       '@vitest/pretty-format': 3.2.1
       '@vitest/runner': 3.2.1
       '@vitest/snapshot': 3.2.1
@@ -1008,9 +1024,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.0
       tinyrainbow: 2.0.0
-      vite: 6.3.5
-      vite-node: 3.2.1
+      vite: 6.3.5(@types/node@22.15.29)
+      vite-node: 3.2.1(@types/node@22.15.29)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.29
     transitivePeerDependencies:
       - jiti
       - less

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
+    "types": ["node", "vitest/globals"],
     "declaration": true,
     "outDir": "dist"
-  }
+  },
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- include vitest/globals and node types in tsconfig
- add @types/node dependency
- update workflow to run pnpm typecheck and pnpm test

## Testing
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684045f80c5c8325b4af7a9ce55778c0