### PR TITLE
Update lint step and fix lint errors

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -15,8 +15,8 @@ jobs:
           version: 9
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
-      - name: Run Biome Check
-        run: npx -y @biomejs/biome check .
+      - name: Run Lint
+        run: pnpm lint
       - name: Run Type Check
         run: pnpm typecheck
       - name: Run Tests

--- a/__tests__/placeholder.test.ts
+++ b/__tests__/placeholder.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest';
 
 describe('placeholder', () => {
   it('works', () => {
-    expect(1).toBe(1)
-  })
-})
+    expect(1).toBe(1);
+  });
+});

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -1,6 +1,6 @@
-import { parseChunks, resolveImport, collectVirtualFiles } from '../src';
-import path from 'path'
-import fs from 'fs'
+import fs from 'node:fs';
+import path from 'node:path';
+import { collectVirtualFiles, parseChunks, resolveImport } from '../src';
 
 describe('parseChunks のテスト', () => {
   const md = [
@@ -13,65 +13,66 @@ describe('parseChunks のテスト', () => {
     '```ts bar',
     'import "#./dep.ts.md:dep"',
     '```',
-  ].join('\n')
+  ].join('\n');
 
-  const chunks = parseChunks(md, '/test/example.ts.md')
+  const chunks = parseChunks(md, '/test/example.ts.md');
   it('チャンクを抽出できる', () => {
-    expect(Object.keys(chunks)).toEqual(['foo', 'bar'])
-    expect(chunks.foo.code.trim()).toBe("console.log('foo')")
-    expect(chunks.foo.start).toBe(4)
-  })
-})
+    expect(Object.keys(chunks)).toEqual(['foo', 'bar']);
+    expect(chunks.foo.code.trim()).toBe("console.log('foo')");
+    expect(chunks.foo.start).toBe(4);
+  });
+});
 
 describe('resolveImport のテスト', () => {
   it('インポート元からの相対パスを解決できる', () => {
-    const info = resolveImport('#../dep.ts.md:main', '/a/b/src/app.ts.md')!
-    expect(info.file).toBe(path.resolve('/a/b/src', '../dep.ts.md'))
-    expect(info.name).toBe('main')
-  })
-})
+    const info = resolveImport('#../dep.ts.md:main', '/a/b/src/app.ts.md');
+    expect(info).not.toBeNull();
+    if (!info) return;
+    expect(info.file).toBe(path.resolve('/a/b/src', '../dep.ts.md'));
+    expect(info.name).toBe('main');
+  });
+});
 
 describe('collectVirtualFiles のテスト', () => {
-  const dir = path.join(__dirname, 'fixtures')
-  const mainPath = path.join(dir, 'main.ts.md')
+  const dir = path.join(__dirname, 'fixtures');
+  const mainPath = path.join(dir, 'main.ts.md');
 
   beforeAll(() => {
-    fs.mkdirSync(dir, { recursive: true })
-    fs.writeFileSync(path.join(dir, 'dep.ts.md'), [
-      '# Dep',
-      '',
-      '```ts dep',
-      "export const msg = 'dep'",
-      '```',
-    ].join('\n'))
-    fs.writeFileSync(mainPath, [
-      '# Main',
-      '',
-      '```ts main',
-      'import "#./dep.ts.md:dep"',
-      'console.log(msg)',
-      '```',
-    ].join('\n'))
-  })
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'dep.ts.md'),
+      ['# Dep', '', '```ts dep', "export const msg = 'dep'", '```'].join('\n'),
+    );
+    fs.writeFileSync(
+      mainPath,
+      [
+        '# Main',
+        '',
+        '```ts main',
+        'import "#./dep.ts.md:dep"',
+        'console.log(msg)',
+        '```',
+      ].join('\n'),
+    );
+  });
 
   afterAll(() => {
-    fs.rmSync(dir, { recursive: true, force: true })
-  })
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
 
   it('再帰的にチャンクを収集できる', () => {
-    const files = collectVirtualFiles(mainPath)
-    const keys = Object.keys(files)
-    expect(keys).toContain(path.resolve(mainPath) + ':main')
-    expect(keys).toContain(path.resolve(dir, 'dep.ts.md') + ':dep')
-  })
+    const files = collectVirtualFiles(mainPath);
+    const keys = Object.keys(files);
+    expect(keys).toContain(`${path.resolve(mainPath)}:main`);
+    expect(keys).toContain(`${path.resolve(dir, 'dep.ts.md')}:dep`);
+  });
 
   it('循環参照を検出できる', () => {
-    const cyclePath = path.join(dir, 'cycle.ts.md')
-    fs.writeFileSync(cyclePath, [
-      '```ts a',
-      'import "#./cycle.ts.md:a"',
-      '```',
-    ].join('\n'))
-    expect(() => collectVirtualFiles(cyclePath)).toThrow('circular')
-  })
-})
+    const cyclePath = path.join(dir, 'cycle.ts.md');
+    fs.writeFileSync(
+      cyclePath,
+      ['```ts a', 'import "#./cycle.ts.md:a"', '```'].join('\n'),
+    );
+    expect(() => collectVirtualFiles(cyclePath)).toThrow('circular');
+  });
+});


### PR DESCRIPTION
## Summary
- run `pnpm lint` in GitHub Actions instead of invoking Biome directly
- apply Biome fixes across the repo
- update tests to satisfy lint rules

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684047acfaa48325b605816a689bf4e1