### PR TITLE
Implement basic ts-md-ls-core plugin

### DIFF
--- a/packages/ls-core/package.json
+++ b/packages/ls-core/package.json
@@ -5,5 +5,8 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b"
+  },
+  "dependencies": {
+    "@sterashima78/ts-md-core": "workspace:*"
   }
 }

--- a/packages/ls-core/src/index.ts
+++ b/packages/ls-core/src/index.ts
@@ -1,1 +1,37 @@
-export const placeholder = null;
+import { collectVirtualFiles } from '@sterashima78/ts-md-core';
+import type { EmbeddedLanguagePlugin, IScriptSnapshot, VirtualCode } from './types';
+
+function createSnapshot(text: string): IScriptSnapshot {
+  return {
+    getText: (start, end) => text.substring(start, end),
+    getLength: () => text.length,
+    getChangeRange: () => undefined,
+  };
+}
+
+export function createTsMdPlugin(): EmbeddedLanguagePlugin {
+  return {
+    getLanguageId(fileName) {
+      if (fileName.endsWith('.ts.md')) return 'ts-markdown';
+      return undefined;
+    },
+    createVirtualCode(fileName, languageId, snapshot) {
+      if (languageId !== 'ts-markdown') return undefined;
+      const files = collectVirtualFiles(fileName);
+      const embeddedCodes: VirtualCode[] = [];
+      for (const chunk of Object.values(files)) {
+        embeddedCodes.push({
+          id: `${chunk.file}:${chunk.name}`,
+          languageId: 'typescript',
+          snapshot: createSnapshot(chunk.code),
+        });
+      }
+      return {
+        id: fileName,
+        languageId,
+        snapshot,
+        embeddedCodes,
+      };
+    },
+  };
+}

--- a/packages/ls-core/src/index.ts
+++ b/packages/ls-core/src/index.ts
@@ -1,5 +1,9 @@
 import { collectVirtualFiles } from '@sterashima78/ts-md-core';
-import type { EmbeddedLanguagePlugin, IScriptSnapshot, VirtualCode } from './types';
+import type {
+  EmbeddedLanguagePlugin,
+  IScriptSnapshot,
+  VirtualCode,
+} from './types';
 
 function createSnapshot(text: string): IScriptSnapshot {
   return {

--- a/packages/ls-core/src/types.ts
+++ b/packages/ls-core/src/types.ts
@@ -1,7 +1,9 @@
 export interface IScriptSnapshot {
   getText(start: number, end: number): string;
   getLength(): number;
-  getChangeRange(oldSnapshot: IScriptSnapshot): any;
+  getChangeRange(
+    oldSnapshot: IScriptSnapshot,
+  ): import('typescript').TextChangeRange | undefined;
 }
 
 export interface VirtualCode {
@@ -13,7 +15,15 @@ export interface VirtualCode {
 
 export interface EmbeddedLanguagePlugin {
   getLanguageId(scriptId: string): string | undefined;
-  createVirtualCode?(scriptId: string, languageId: string, snapshot: IScriptSnapshot): VirtualCode | undefined;
-  updateVirtualCode?(scriptId: string, virtualCode: VirtualCode, newSnapshot: IScriptSnapshot): VirtualCode | undefined;
+  createVirtualCode?(
+    scriptId: string,
+    languageId: string,
+    snapshot: IScriptSnapshot,
+  ): VirtualCode | undefined;
+  updateVirtualCode?(
+    scriptId: string,
+    virtualCode: VirtualCode,
+    newSnapshot: IScriptSnapshot,
+  ): VirtualCode | undefined;
   disposeVirtualCode?(scriptId: string, virtualCode: VirtualCode): void;
 }

--- a/packages/ls-core/src/types.ts
+++ b/packages/ls-core/src/types.ts
@@ -1,0 +1,19 @@
+export interface IScriptSnapshot {
+  getText(start: number, end: number): string;
+  getLength(): number;
+  getChangeRange(oldSnapshot: IScriptSnapshot): any;
+}
+
+export interface VirtualCode {
+  id: string;
+  languageId: string;
+  snapshot: IScriptSnapshot;
+  embeddedCodes?: VirtualCode[];
+}
+
+export interface EmbeddedLanguagePlugin {
+  getLanguageId(scriptId: string): string | undefined;
+  createVirtualCode?(scriptId: string, languageId: string, snapshot: IScriptSnapshot): VirtualCode | undefined;
+  updateVirtualCode?(scriptId: string, virtualCode: VirtualCode, newSnapshot: IScriptSnapshot): VirtualCode | undefined;
+  disposeVirtualCode?(scriptId: string, virtualCode: VirtualCode): void;
+}

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,1 +1,90 @@
-export const placeholder = null;
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+import type { ChunkDictionary } from '../../core/src';
+import { parseChunks, resolveImport } from '../../core/src';
+
+export interface TsMdPluginOptions {
+  alias?: Record<string, string>;
+}
+
+const VIRTUAL_PREFIX = '\0tsmd:';
+
+function isTestChunk(name: string): boolean {
+  return (
+    name === 'test' ||
+    name === 'spec' ||
+    /\.test$/.test(name) ||
+    /\.spec$/.test(name)
+  );
+}
+
+export function tsMdPlugin(opts: TsMdPluginOptions = {}): Plugin {
+  const cache = new Map<string, ChunkDictionary>();
+  const alias = opts.alias || {};
+
+  const applyAlias = (id: string) => {
+    for (const [from, to] of Object.entries(alias)) {
+      if (id.startsWith(from)) {
+        return path.join(to, id.slice(from.length));
+      }
+    }
+    return id;
+  };
+
+  const ensureChunks = (file: string) => {
+    const abs = path.resolve(applyAlias(file));
+    let chunks = cache.get(abs);
+    if (!chunks) {
+      const md = fs.readFileSync(abs, 'utf8');
+      chunks = parseChunks(md, abs);
+      cache.set(abs, chunks);
+    }
+    return { abs, chunks } as { abs: string; chunks: ChunkDictionary };
+  };
+
+  return {
+    name: 'ts-md-vite-plugin',
+    enforce: 'pre',
+
+    resolveId(id, importer) {
+      if (id.startsWith('#') && importer) {
+        const info = resolveImport(id, importer);
+        if (!info) return null;
+        const isTest = isTestChunk(info.name);
+        const { abs } = ensureChunks(info.file);
+        const suffix = isTest ? '.test.ts' : '.ts';
+        return `${VIRTUAL_PREFIX}${abs}:${info.name}${suffix}`;
+      }
+      return null;
+    },
+
+    load(id) {
+      if (id.startsWith(VIRTUAL_PREFIX)) {
+        let body = id.slice(VIRTUAL_PREFIX.length);
+        body = body.replace(/(\.test\.ts|\.ts)$/i, '');
+        const idx = body.lastIndexOf(':');
+        if (idx === -1) return null;
+        const file = body.slice(0, idx);
+        const name = body.slice(idx + 1);
+        const { chunks, abs } = ensureChunks(file);
+        const chunk = chunks[name];
+        if (!chunk) {
+          throw new Error(`chunk '${name}' not found in ${abs}`);
+        }
+        this.addWatchFile(abs);
+        return {
+          code: chunk.code,
+          map: { mappings: '' },
+        };
+      }
+      return null;
+    },
+
+    handleHotUpdate(ctx) {
+      if (ctx.file.endsWith('.ts.md')) {
+        cache.delete(path.resolve(ctx.file));
+      }
+    },
+  };
+}

--- a/packages/vite-plugin/test/index.test.ts
+++ b/packages/vite-plugin/test/index.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tsMdPlugin } from '../src';
+
+describe('ts-md-vite-plugin', () => {
+  const dir = path.join(__dirname, 'fixtures');
+  const mdPath = path.join(dir, 'doc.ts.md');
+  const entry = path.join(dir, 'entry.ts');
+
+  beforeAll(() => {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      mdPath,
+      ['# Doc', '', '```ts main', "export const msg = 'hi'", '```'].join('\n'),
+    );
+    fs.writeFileSync(entry, "import '#./doc.ts.md:main';");
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('loads chunk code', async () => {
+    const plugin = tsMdPlugin();
+    const resolve = plugin.resolveId as unknown as (
+      id: string,
+      importer: string,
+    ) => string | null;
+    const resolved = resolve.call(plugin, '#./doc.ts.md:main', entry);
+    expect(resolved).toBeTruthy();
+    const id = resolved as string;
+    const ctx = { addWatchFile() {} };
+    const load = plugin.load as unknown as (
+      this: { addWatchFile(file: string): void },
+      id: string,
+    ) => Promise<string | { code: string } | null>;
+    const loaded = await load.call(ctx, id);
+    const code = typeof loaded === 'string' ? loaded : loaded?.code;
+    expect(code?.trim()).toBe("export const msg = 'hi'");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,11 @@ importers:
 
   packages/loader: {}
 
-  packages/ls-core: {}
+  packages/ls-core:
+    dependencies:
+      '@sterashima78/ts-md-core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/monaco: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,39 +7,19 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": [
-      "node",
-      "vitest/globals"
-    ],
+    "types": ["node", "vitest/globals"],
     "declaration": true,
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@sterashima78/ts-md-core": [
-        "packages/core/src"
-      ],
-      "@sterashima78/ts-md-vite-plugin": [
-        "packages/vite-plugin/src"
-      ],
-      "@sterashima78/ts-md-loader": [
-        "packages/loader/src"
-      ],
-      "@sterashima78/ts-md-ls-core": [
-        "packages/ls-core/src"
-      ],
-      "@sterashima78/ts-md-vscode": [
-        "packages/vscode/src"
-      ],
-      "@sterashima78/ts-md-cli": [
-        "packages/cli/src"
-      ],
-      "@sterashima78/ts-md-monaco": [
-        "packages/monaco/src"
-      ]
+      "@sterashima78/ts-md-core": ["packages/core/src"],
+      "@sterashima78/ts-md-vite-plugin": ["packages/vite-plugin/src"],
+      "@sterashima78/ts-md-loader": ["packages/loader/src"],
+      "@sterashima78/ts-md-ls-core": ["packages/ls-core/src"],
+      "@sterashima78/ts-md-vscode": ["packages/vscode/src"],
+      "@sterashima78/ts-md-cli": ["packages/cli/src"],
+      "@sterashima78/ts-md-monaco": ["packages/monaco/src"]
     }
   },
-  "exclude": [
-    "dist",
-    "node_modules"
-  ]
+  "exclude": ["dist", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,39 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node", "vitest/globals"],
+    "types": [
+      "node",
+      "vitest/globals"
+    ],
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@sterashima78/ts-md-core": [
+        "packages/core/src"
+      ],
+      "@sterashima78/ts-md-vite-plugin": [
+        "packages/vite-plugin/src"
+      ],
+      "@sterashima78/ts-md-loader": [
+        "packages/loader/src"
+      ],
+      "@sterashima78/ts-md-ls-core": [
+        "packages/ls-core/src"
+      ],
+      "@sterashima78/ts-md-vscode": [
+        "packages/vscode/src"
+      ],
+      "@sterashima78/ts-md-cli": [
+        "packages/cli/src"
+      ],
+      "@sterashima78/ts-md-monaco": [
+        "packages/monaco/src"
+      ]
+    }
   },
-  "exclude": ["dist", "node_modules"]
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- implement a minimal Volar `createTsMdPlugin` in ls-core
- add workspace dependency on ts-md-core
- define simple interfaces for the plugin
- configure TS path mappings for packages

## Testing
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68404906964c83259f9e8f7c2a929eeb