### PR TITLE
Implement ts-md-vite-plugin

### DIFF
--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,1 +1,90 @@
-export const placeholder = null;
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Plugin } from 'vite';
+import type { ChunkDictionary } from '../../core/src';
+import { parseChunks, resolveImport } from '../../core/src';
+
+export interface TsMdPluginOptions {
+  alias?: Record<string, string>;
+}
+
+const VIRTUAL_PREFIX = '\0tsmd:';
+
+function isTestChunk(name: string): boolean {
+  return (
+    name === 'test' ||
+    name === 'spec' ||
+    /\.test$/.test(name) ||
+    /\.spec$/.test(name)
+  );
+}
+
+export function tsMdPlugin(opts: TsMdPluginOptions = {}): Plugin {
+  const cache = new Map<string, ChunkDictionary>();
+  const alias = opts.alias || {};
+
+  const applyAlias = (id: string) => {
+    for (const [from, to] of Object.entries(alias)) {
+      if (id.startsWith(from)) {
+        return path.join(to, id.slice(from.length));
+      }
+    }
+    return id;
+  };
+
+  const ensureChunks = (file: string) => {
+    const abs = path.resolve(applyAlias(file));
+    let chunks = cache.get(abs);
+    if (!chunks) {
+      const md = fs.readFileSync(abs, 'utf8');
+      chunks = parseChunks(md, abs);
+      cache.set(abs, chunks);
+    }
+    return { abs, chunks } as { abs: string; chunks: ChunkDictionary };
+  };
+
+  return {
+    name: 'ts-md-vite-plugin',
+    enforce: 'pre',
+
+    resolveId(id, importer) {
+      if (id.startsWith('#') && importer) {
+        const info = resolveImport(id, importer);
+        if (!info) return null;
+        const isTest = isTestChunk(info.name);
+        const { abs } = ensureChunks(info.file);
+        const suffix = isTest ? '.test.ts' : '.ts';
+        return `${VIRTUAL_PREFIX}${abs}:${info.name}${suffix}`;
+      }
+      return null;
+    },
+
+    load(id) {
+      if (id.startsWith(VIRTUAL_PREFIX)) {
+        let body = id.slice(VIRTUAL_PREFIX.length);
+        body = body.replace(/(\.test\.ts|\.ts)$/i, '');
+        const idx = body.lastIndexOf(':');
+        if (idx === -1) return null;
+        const file = body.slice(0, idx);
+        const name = body.slice(idx + 1);
+        const { chunks, abs } = ensureChunks(file);
+        const chunk = chunks[name];
+        if (!chunk) {
+          throw new Error(`chunk '${name}' not found in ${abs}`);
+        }
+        this.addWatchFile(abs);
+        return {
+          code: chunk.code,
+          map: { mappings: '' },
+        };
+      }
+      return null;
+    },
+
+    handleHotUpdate(ctx) {
+      if (ctx.file.endsWith('.ts.md')) {
+        cache.delete(path.resolve(ctx.file));
+      }
+    },
+  };
+}

--- a/packages/vite-plugin/test/index.test.ts
+++ b/packages/vite-plugin/test/index.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { tsMdPlugin } from '../src';
+
+describe('ts-md-vite-plugin', () => {
+  const dir = path.join(__dirname, 'fixtures');
+  const mdPath = path.join(dir, 'doc.ts.md');
+  const entry = path.join(dir, 'entry.ts');
+
+  beforeAll(() => {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      mdPath,
+      ['# Doc', '', '```ts main', "export const msg = 'hi'", '```'].join('\n'),
+    );
+    fs.writeFileSync(entry, "import '#./doc.ts.md:main';");
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('loads chunk code', async () => {
+    const plugin = tsMdPlugin();
+    const resolve = plugin.resolveId as unknown as (
+      id: string,
+      importer: string,
+    ) => string | null;
+    const resolved = resolve.call(plugin, '#./doc.ts.md:main', entry);
+    expect(resolved).toBeTruthy();
+    const id = resolved as string;
+    const ctx = { addWatchFile() {} };
+    const load = plugin.load as unknown as (
+      this: { addWatchFile(file: string): void },
+      id: string,
+    ) => Promise<string | { code: string } | null>;
+    const loaded = await load.call(ctx, id);
+    const code = typeof loaded === 'string' ? loaded : loaded?.code;
+    expect(code?.trim()).toBe("export const msg = 'hi'");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node", "vitest/globals"],
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@sterashima78/ts-md-core": ["packages/core/src"]
+    }
   },
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- implement vite plugin for ts-md
- add tests for ts-md-vite-plugin
- configure path mapping for core package

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm exec vite build`


------
https://chatgpt.com/codex/tasks/task_e_684048b10d688325be21de772d6d4bf4