### PR TITLE
Implement basic ls-core plugin

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,7 +75,7 @@ export function collectVirtualFiles(entry: string): Record<string, Chunk> {
     }
     visited.add(file);
     for (const chunk of Object.values(chunks)) {
-      const importRegex = /import\s+['"](#.+?)['"]/g;
+      const importRegex = /import\s+(?:.+?\s+from\s+)?['"](#.+?)['"]/g;
       let match: RegExpExecArray | null = importRegex.exec(chunk.code);
       while (match) {
         const info = resolveImport(match[1], file);

--- a/packages/ls-core/src/index.ts
+++ b/packages/ls-core/src/index.ts
@@ -1,1 +1,97 @@
-export const placeholder = null;
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { type Chunk, collectVirtualFiles, resolveImport } from '../../core/src';
+
+export interface VirtualFile {
+  fileName: string;
+  code: string;
+}
+
+export interface EmbeddedLanguagePlugin {
+  createProgram(entry: string, options?: ts.CompilerOptions): ts.Program;
+}
+
+function toVirtualFileName(chunk: Chunk): string {
+  const base = path.resolve(chunk.file).replace(/[:\\]/g, '_');
+  return `${base}___${chunk.name}.ts`;
+}
+
+export function createTsMdPlugin(): EmbeddedLanguagePlugin {
+  return {
+    createProgram(entry: string, options: ts.CompilerOptions = {}): ts.Program {
+      const files = collectVirtualFiles(entry);
+      const virtualFiles = new Map<string, string>();
+      const reverse = new Map<string, Chunk>();
+      for (const chunk of Object.values(files)) {
+        const vName = toVirtualFileName(chunk);
+        virtualFiles.set(vName, chunk.code);
+        reverse.set(vName, chunk);
+      }
+      const compilerOptions: ts.CompilerOptions = {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ESNext,
+        skipLibCheck: true,
+        ...options,
+      };
+      const host = ts.createCompilerHost(compilerOptions);
+      const defaultResolveModuleNames = host.resolveModuleNames?.bind(host);
+      host.resolveModuleNames = (moduleNames, containingFile, ...rest) => {
+        const results: (ts.ResolvedModule | undefined)[] = [];
+        for (const name of moduleNames) {
+          if (name.startsWith('#')) {
+            const original =
+              reverse.get(containingFile)?.file ?? containingFile;
+            const info = resolveImport(name, original);
+            if (info) {
+              const base = path.resolve(info.file).replace(/[:\\]/g, '_');
+              const fn = `${base}___${info.name}.ts`;
+              results.push({
+                resolvedFileName: fn,
+                extension: ts.Extension.Ts,
+              } as ts.ResolvedModuleFull);
+              continue;
+            }
+          }
+          if (defaultResolveModuleNames) {
+            const resolved = defaultResolveModuleNames(
+              [name],
+              containingFile,
+              ...rest,
+            )[0];
+            results.push(resolved);
+          } else {
+            const resolved = ts.resolveModuleName(
+              name,
+              containingFile,
+              compilerOptions,
+              host,
+            ).resolvedModule;
+            results.push(resolved);
+          }
+        }
+        return results;
+      };
+      host.fileExists = (fileName: string) => {
+        return virtualFiles.has(fileName) || ts.sys.fileExists(fileName);
+      };
+      host.readFile = (fileName: string) => {
+        return virtualFiles.get(fileName) ?? ts.sys.readFile(fileName);
+      };
+      host.getSourceFile = (fileName, languageVersion) => {
+        const content = virtualFiles.get(fileName);
+        if (content !== undefined) {
+          return ts.createSourceFile(fileName, content, languageVersion, true);
+        }
+        const text = ts.sys.readFile(fileName);
+        if (text === undefined) return undefined;
+        return ts.createSourceFile(fileName, text, languageVersion, true);
+      };
+      return ts.createProgram(
+        Array.from(virtualFiles.keys()),
+        compilerOptions,
+        host,
+      );
+    },
+  };
+}

--- a/packages/ls-core/test/index.test.ts
+++ b/packages/ls-core/test/index.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+import { createTsMdPlugin } from '../src';
+
+const plugin = createTsMdPlugin();
+
+describe('ts-md-ls-core diagnostics', () => {
+  const dir = path.join(__dirname, 'fixtures');
+  const aPath = path.join(dir, 'a.ts.md');
+  const mainPath = path.join(dir, 'main.ts.md');
+
+  beforeAll(() => {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      aPath,
+      ['# A', '', '```ts foo', "export const msg: number = 'hi'", '```'].join(
+        '\n',
+      ),
+    );
+    fs.writeFileSync(
+      mainPath,
+      [
+        '# Main',
+        '',
+        '```ts main',
+        "import '#./a.ts.md:foo'",
+        "import { msg } from '#./a.ts.md:foo'",
+        'console.log(msg)',
+        '```',
+      ].join('\n'),
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reports diagnostics across docs', () => {
+    const program = plugin.createProgram(mainPath);
+    const diagnostics = ts.getPreEmitDiagnostics(program);
+    expect(diagnostics.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement simple TypeScript plugin for `ts-md-ls-core`
- support cross-doc imports and virtual file creation
- adjust core to detect `from` syntax in imports
- add diagnostics test for ls-core

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6840b380399083258c3b1c4a1091b7d1