### PR TITLE
Fix loader resolve format

### DIFF
--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -30,7 +30,7 @@ export const resolve: Resolve = async (specifier, context, defaultResolve) => {
     if (info) {
       const abs = path.resolve(info.file);
       const url = `${VIRTUAL_PREFIX}${abs}:${info.name}`;
-      return { url, shortCircuit: true };
+      return { url, format: 'module', shortCircuit: true };
     }
   }
 
@@ -38,14 +38,22 @@ export const resolve: Resolve = async (specifier, context, defaultResolve) => {
     const abs = parentURL
       ? path.resolve(path.dirname(parentURL), specPath)
       : path.resolve(specPath);
-    return { url: `${VIRTUAL_PREFIX}${abs}:main`, shortCircuit: true };
+    return {
+      url: `${VIRTUAL_PREFIX}${abs}:main`,
+      format: 'module',
+      shortCircuit: true,
+    };
   }
 
   if (specPath.endsWith('.ts')) {
     const abs = parentURL
       ? path.resolve(path.dirname(parentURL), specPath)
       : path.resolve(specPath);
-    return { url: pathToFileURL(abs).href, shortCircuit: true };
+    return {
+      url: pathToFileURL(abs).href,
+      format: 'module',
+      shortCircuit: true,
+    };
   }
 
   return defaultResolve(specifier, context, defaultResolve);


### PR DESCRIPTION
## Summary
- ensure the loader's resolve hook marks `.ts.md` and `.ts` files as modules
- apply the same module format for `#` chunk imports

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: Unknown file extension '.ts' for core)*

------
https://chatgpt.com/codex/tasks/task_e_68418a9120748325b38c1e6a8ca909b5