### PR TITLE
Update ls-core resolveFileName to use file URLs

### DIFF
--- a/packages/ls-core/src/plugin.ts
+++ b/packages/ls-core/src/plugin.ts
@@ -1,33 +1,68 @@
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { LanguagePlugin } from '@volar/language-core';
 import type ts from 'typescript';
 import { getChunkDict } from './parsers';
 import { TsMdVirtualFile } from './virtual-file';
 
 export const tsMdLanguagePlugin = {
-  getLanguageId(fileName) {
-    return fileName.endsWith('.ts.md') ? 'ts-md' : undefined;
+  getLanguageId(fileName: string) {
+    const name =
+      typeof fileName === 'string'
+        ? fileName
+        : (fileName as unknown as { fsPath: string }).fsPath;
+    return name.endsWith('.ts.md') ? 'ts-md' : undefined;
   },
-  createVirtualCode(fileName, languageId, snapshot) {
+  createVirtualCode(
+    fileName: string,
+    languageId: string,
+    snapshot: ts.IScriptSnapshot,
+  ) {
     if (languageId !== 'ts-md') return;
-    const dict = getChunkDict(snapshot, fileName);
-    return new TsMdVirtualFile(snapshot, fileName, dict);
+    const filePath =
+      typeof fileName === 'string'
+        ? fileName
+        : (fileName as unknown as { fsPath: string }).fsPath;
+    const dict = getChunkDict(snapshot, filePath);
+    const uri =
+      typeof fileName === 'string'
+        ? pathToFileURL(fileName).href
+        : (fileName as unknown as { toString(): string }).toString();
+    return new TsMdVirtualFile(snapshot, uri, dict);
   },
 
-  updateVirtualCode(fileName, oldFile, snapshot) {
-    if (!fileName.endsWith('.ts.md')) return;
-    const dict = getChunkDict(snapshot, fileName);
+  updateVirtualCode(
+    fileName: string,
+    oldFile: TsMdVirtualFile,
+    snapshot: ts.IScriptSnapshot,
+  ) {
+    const name =
+      typeof fileName === 'string'
+        ? fileName
+        : (fileName as unknown as { fsPath: string }).fsPath;
+    if (!name.endsWith('.ts.md')) return;
+    const filePath =
+      typeof fileName === 'string'
+        ? fileName
+        : (fileName as unknown as { fsPath: string }).fsPath;
+    const dict = getChunkDict(snapshot, filePath);
     oldFile.update(snapshot, dict);
     return oldFile;
   },
 
-  resolveFileName(specifier, fromFile) {
+  resolveFileName(specifier: string, fromFile: string) {
     if (!specifier.startsWith('#')) return;
-    const match = specifier.match(/^#([^:]+):(.+)$/);
-    if (!match) return;
-    const [, rel, chunk] = match;
-    const abs = path.resolve(path.dirname(fromFile), rel);
-    return `#${abs}:${chunk}`;
+    const body = specifier.slice(1);
+    const idx = body.lastIndexOf(':');
+    if (idx === -1) return;
+    const rel = body.slice(0, idx);
+    const chunk = body.slice(idx + 1);
+    const baseFile =
+      typeof fromFile === 'string'
+        ? fromFile
+        : (fromFile as unknown as { fsPath: string }).fsPath;
+    const abs = path.resolve(path.dirname(baseFile), rel);
+    return `#${pathToFileURL(abs).href}:${chunk}`;
   },
 } as LanguagePlugin<string, TsMdVirtualFile> & {
   resolveFileName(specifier: string, fromFile: string): string | undefined;


### PR DESCRIPTION
## Summary
- adjust `packages/ls-core/src/plugin.ts` to return file URL strings from `resolveFileName`
- normalize inputs that may be `URI` objects when creating virtual files

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*

------
https://chatgpt.com/codex/tasks/task_e_68418d76aa2c8325b636466ad7625c79