### PR TITLE
Implement ts-md-cli

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": []
+    "ignore": ["**/dist/**"]
   },
   "formatter": {
     "enabled": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,9 +1,30 @@
 {
   "name": "@sterashima78/ts-md-cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "tsmd": "./dist/index.js"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsup src/index.ts --format esm --dts",
+    "dev": "tsup src/index.ts --watch",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@sterashima78/ts-md-core": "workspace:*",
+    "@sterashima78/ts-md-loader": "workspace:*",
+    "@sterashima78/ts-md-ls-core": "workspace:*",
+    "commander": "^11",
+    "fast-glob": "^3.3.3",
+    "picocolors": "^1.0.0",
+    "typescript": "^5.5",
+    "@volar/language-service": "^2.4.14",
+    "vscode-uri": "^3.0.8"
+  },
+  "devDependencies": {
+    "tsup": "^8",
+    "vitest": "^1"
   }
 }

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import {
+  type TsMdVirtualFile,
+  tsMdLanguagePlugin,
+} from '@sterashima78/ts-md-ls-core';
+import {
+  type Language,
+  type LanguagePlugin,
+  type SourceScript,
+  createLanguage,
+  createLanguageService,
+} from '@volar/language-service';
+import pc from 'picocolors';
+import ts from 'typescript';
+import { URI } from 'vscode-uri';
+import { expandGlobs } from '../utils/globs';
+
+export async function runCheck(globs: string[]) {
+  const files = await expandGlobs(globs);
+  if (!files.length) {
+    console.log(pc.yellow('No .ts.md files found.'));
+    return;
+  }
+
+  const scripts = new Map<URI, SourceScript<URI>>();
+  let language!: Language<URI>;
+  language = createLanguage<URI>(
+    [tsMdLanguagePlugin as unknown as LanguagePlugin<URI, TsMdVirtualFile>],
+    scripts,
+    (uri) => {
+      if (scripts.has(uri)) return;
+      const filePath = uri.fsPath;
+      const snapshot = ts.ScriptSnapshot.fromString(
+        fs.readFileSync(filePath, 'utf8'),
+      );
+      language.scripts.set(uri, snapshot, 'ts-md');
+    },
+  );
+  const ls = createLanguageService(language, [], { workspaceFolders: [] }, {});
+
+  let errorCount = 0;
+  for (const file of files) {
+    const uri = URI.file(file);
+    language.scripts.get(uri);
+    const diags = await ls.getDiagnostics(uri);
+    for (const d of diags) {
+      console.error(
+        `${pc.red('error')} ${file}:${d.range.start.line + 1}:${d.range.start.character + 1} ${d.message}`,
+      );
+    }
+    errorCount += diags.length;
+  }
+  if (errorCount) process.exit(1);
+}

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,0 +1,14 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { spawnNode } from '../utils/spawn';
+
+const require = createRequire(import.meta.url);
+
+export async function runTsMd(entryFile: string, nodeArgs: string[]) {
+  const loader = require.resolve('@sterashima78/ts-md-loader');
+  const tsx = require.resolve('tsx/esm');
+
+  const args = ['--import', tsx, '--loader', loader, entryFile, ...nodeArgs];
+  const code = await spawnNode(args, { cwd: path.dirname(entryFile) });
+  process.exit(code);
+}

--- a/packages/cli/src/commands/tangle.ts
+++ b/packages/cli/src/commands/tangle.ts
@@ -1,0 +1,22 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parseChunks } from '@sterashima78/ts-md-core';
+import { expandGlobs } from '../utils/globs';
+
+export async function runTangle(inputGlobs: string[], outDir = 'dist') {
+  const files = await expandGlobs(inputGlobs);
+  await fs.mkdir(outDir, { recursive: true });
+
+  for (const file of files) {
+    const md = await fs.readFile(file, 'utf8');
+    const dict = parseChunks(md, file);
+
+    for (const [chunk, info] of Object.entries(dict)) {
+      const rel = path.join(path.basename(file, '.ts.md'), `${chunk}.ts`);
+      const target = path.join(outDir, rel);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await fs.writeFile(target, info.code, 'utf8');
+      console.log(`✨ wrote ${target}`);
+    }
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,32 @@
-export const placeholder = null;
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { runCheck } from './commands/check';
+import { runTsMd } from './commands/run';
+import { runTangle } from './commands/tangle';
+
+const program = new Command('tsmd');
+
+program
+  .command('check [globs...]')
+  .description('Type-check .ts.md files')
+  .action((globs: string[]) => runCheck(globs));
+
+program
+  .command('tangle [globs...]')
+  .option('-o, --outDir <dir>', 'output directory', 'dist')
+  .description('Extract code chunks to real files')
+  .action((globs: string[], opts: { outDir: string }) =>
+    runTangle(globs, opts.outDir),
+  );
+
+program
+  .command('run <file>')
+  .allowUnknownOption()
+  .description('Execute a .ts.md file with Node')
+  .action((file: string, _opts: unknown, cmd: Command) => {
+    const rest =
+      cmd.parent?.args.slice(cmd.parent.args.indexOf('run') + 2) ?? [];
+    runTsMd(file, rest);
+  });
+
+program.parse();

--- a/packages/cli/src/utils/globs.ts
+++ b/packages/cli/src/utils/globs.ts
@@ -1,0 +1,5 @@
+import fg from 'fast-glob';
+
+export async function expandGlobs(globs: string[]): Promise<string[]> {
+  return fg(globs.length ? globs : ['**/*.ts.md'], { absolute: true });
+}

--- a/packages/cli/src/utils/spawn.ts
+++ b/packages/cli/src/utils/spawn.ts
@@ -1,0 +1,14 @@
+import { spawn } from 'node:child_process';
+
+export function spawnNode(
+  args: string[],
+  opts: { cwd?: string },
+): Promise<number> {
+  return new Promise((res) => {
+    const p = spawn(process.execPath, args, {
+      stdio: 'inherit',
+      cwd: opts.cwd ?? process.cwd(),
+    });
+    p.on('close', (code) => res(code ?? 0));
+  });
+}

--- a/packages/cli/test/index.test.ts
+++ b/packages/cli/test/index.test.ts
@@ -1,0 +1,104 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+function build(src: string, out: string) {
+  const source = fs.readFileSync(src, 'utf8');
+  const result = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ESNext,
+    },
+  });
+  fs.mkdirSync(path.dirname(out), { recursive: true });
+  fs.writeFileSync(out, result.outputText);
+}
+
+describe('ts-md-cli', () => {
+  const dir = path.join(__dirname, 'fixtures');
+  const cliEntry = path.join(__dirname, '..', 'src', 'index.ts');
+
+  beforeAll(() => {
+    fs.mkdirSync(dir, { recursive: true });
+
+    const coreSrc = path.join(__dirname, '..', '..', 'core', 'src');
+    const coreDist = path.join(__dirname, '..', '..', 'core', 'dist');
+    build(path.join(coreSrc, 'index.ts'), path.join(coreDist, 'index.js'));
+
+    const loaderSrc = path.join(__dirname, '..', '..', 'loader', 'src');
+    const loaderDist = path.join(__dirname, '..', '..', 'loader', 'dist');
+    build(path.join(loaderSrc, 'index.ts'), path.join(loaderDist, 'index.js'));
+
+    const lsSrc = path.join(__dirname, '..', '..', 'ls-core', 'src');
+    const lsDist = path.join(__dirname, '..', '..', 'ls-core', 'dist');
+    build(path.join(lsSrc, 'index.ts'), path.join(lsDist, 'index.js'));
+    build(path.join(lsSrc, 'plugin.ts'), path.join(lsDist, 'plugin.js'));
+    build(path.join(lsSrc, 'parsers.ts'), path.join(lsDist, 'parsers.js'));
+    build(
+      path.join(lsSrc, 'virtual-file.ts'),
+      path.join(lsDist, 'virtual-file.js'),
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(path.join(__dirname, '..', '..', 'core', 'dist'), {
+      recursive: true,
+      force: true,
+    });
+    fs.rmSync(path.join(__dirname, '..', '..', 'loader', 'dist'), {
+      recursive: true,
+      force: true,
+    });
+    fs.rmSync(path.join(__dirname, '..', '..', 'ls-core', 'dist'), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  const run = (args: string[], cwd?: string) => {
+    return execSync(`node --import tsx/esm ${cliEntry} ${args.join(' ')}`, {
+      encoding: 'utf8',
+      cwd,
+    });
+  };
+
+  it('check exits with error', () => {
+    const f = path.join(dir, 'err.ts.md');
+    fs.writeFileSync(
+      f,
+      ['# Doc', '', '```ts main', "const a: number = 'b'", '```'].join('\n'),
+    );
+    let status = 0;
+    try {
+      run(['check', f]);
+    } catch (e: unknown) {
+      status = (e as { status: number }).status;
+    }
+    expect(status).toBe(1);
+  });
+
+  it('tangle outputs files', () => {
+    const f = path.join(dir, 'demo.ts.md');
+    fs.writeFileSync(
+      f,
+      ['# Demo', '', '```ts foo', "console.log('hi')", '```'].join('\n'),
+    );
+    const out = path.join(dir, 'out');
+    run(['tangle', f, '-o', out]);
+    const target = path.join(out, 'demo', 'foo.ts');
+    const code = fs.readFileSync(target, 'utf8');
+    expect(code.trim()).toBe("console.log('hi')");
+  });
+
+  it('run executes file', () => {
+    const f = path.join(dir, 'run.ts.md');
+    fs.writeFileSync(
+      f,
+      ['```ts main', "console.log('works')", '```'].join('\n'),
+    );
+    const out = run(['run', f]);
+    expect(out.trim()).toBe('works');
+  });
+});

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  target: 'node18',
+  format: ['esm'],
+  shims: false,
+  splitting: false,
+  clean: true,
+  dts: true,
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,10 +2,10 @@
   "name": "@sterashima78/ts-md-core",
   "version": "0.0.0",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./dist/index.js"
   },
   "scripts": {
     "build": "tsc -b"

--- a/packages/ls-core/src/index.ts
+++ b/packages/ls-core/src/index.ts
@@ -1,2 +1,5 @@
-export { tsMdLanguagePlugin as createTsMdPlugin } from './plugin';
-export type { TsMdVirtualFile } from './virtual-file';
+export {
+  tsMdLanguagePlugin,
+  tsMdLanguagePlugin as createTsMdPlugin,
+} from './plugin.js';
+export type { TsMdVirtualFile } from './virtual-file.js';

--- a/packages/ls-core/src/plugin.ts
+++ b/packages/ls-core/src/plugin.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import type { LanguagePlugin } from '@volar/language-core';
 import type ts from 'typescript';
-import { getChunkDict } from './parsers';
-import { TsMdVirtualFile } from './virtual-file';
+import { getChunkDict } from './parsers.js';
+import { TsMdVirtualFile } from './virtual-file.js';
 
 export const tsMdLanguagePlugin = {
   getLanguageId(fileName) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,9 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@sterashima78/ts-md-core": ["packages/core/src"]
+      "@sterashima78/ts-md-core": ["packages/core/src"],
+      "@sterashima78/ts-md-loader": ["packages/loader/src"],
+      "@sterashima78/ts-md-ls-core": ["packages/ls-core/src"]
     }
   },
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- implement `runCheck` using Volar language service
- expose `.js` extension in ls-core exports
- add vscode-uri dependency
- restore tsconfig path mappings for runtime

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68418737654c8325b0d67bc978e8f4d5