### PR TITLE
Add package test and typecheck scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.log
+.trubo

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,10 +7,10 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@sterashima78/ts-md-core": "workspace:*"

--- a/packages/ls-core/package.json
+++ b/packages/ls-core/package.json
@@ -4,11 +4,11 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@volar/language-core": "^2.4.14",

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   }
 }

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -10,11 +10,11 @@
     "./webpack": "./dist/webpack.js",
     "./esbuild": "./dist/esbuild.js"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsup src/index.ts src/vite.ts src/rollup.ts src/webpack.ts src/esbuild.ts --format esm,cjs --dts"
+    "build": "tsup src/index.ts src/vite.ts src/rollup.ts src/webpack.ts src/esbuild.ts --format esm,cjs --dts",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@sterashima78/ts-md-core": "workspace:*"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   }
 }


### PR DESCRIPTION
## Summary
- add `typecheck` and `test` scripts to each package
- ignore `.trubo` directory

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/latest)*

------
https://chatgpt.com/codex/tasks/task_e_6841f81dcbe883259cb40b1254618d10