### PR TITLE
Remove manual core transpilation from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 dist
 *.log
-.trubo
+.turbo

--- a/packages/loader/test/index.test.ts
+++ b/packages/loader/test/index.test.ts
@@ -9,9 +9,14 @@ describe('ts-md-loader', () => {
   const md = path.join(dir, 'doc.ts.md');
   const loaderSrc = path.join(__dirname, '..', 'src', 'index.ts');
   const builtLoader = path.join(dir, 'loader.mjs');
-  const coreSrcDir = path.join(__dirname, '..', '..', 'core', 'src');
-  const coreDist = path.join(__dirname, '..', '..', 'core', 'dist');
-  const builtCore = path.join(coreDist, 'index.js');
+  const builtCore = path.join(
+    __dirname,
+    '..',
+    '..',
+    'core',
+    'dist',
+    'index.js',
+  );
 
   beforeAll(() => {
     fs.mkdirSync(dir, { recursive: true });
@@ -33,36 +38,18 @@ describe('ts-md-loader', () => {
       pathToFileURL(builtCore).href,
     );
     fs.writeFileSync(builtLoader, loaderCode);
-
-    fs.mkdirSync(coreDist, { recursive: true });
-    for (const file of fs.readdirSync(coreSrcDir)) {
-      if (!file.endsWith('.ts')) continue;
-      const src = path.join(coreSrcDir, file);
-      const dest = path.join(coreDist, file.replace(/\.ts$/, '.js'));
-      const srcText = fs.readFileSync(src, 'utf8');
-      const out = ts.transpileModule(srcText, {
-        compilerOptions: {
-          module: ts.ModuleKind.ESNext,
-          target: ts.ScriptTarget.ESNext,
-        },
-      });
-      const js = out.outputText.replace(
-        /from '(\.\/.+?)'/g,
-        (m, p) => `from '${p}.js'`,
-      );
-      fs.writeFileSync(dest, js);
-    }
   });
 
   afterAll(() => {
     fs.rmSync(dir, { recursive: true, force: true });
-    // keep coreDist to avoid conflicts across parallel tests
   });
 
   it('runs markdown file', () => {
     const out = execSync(
       `node --import tsx/esm --loader ${builtLoader} ${md}`,
-      { encoding: 'utf8' },
+      {
+        encoding: 'utf8',
+      },
     );
     expect(out.trim()).toBe('loader works');
   });

--- a/packages/ls-core/test/index.test.ts
+++ b/packages/ls-core/test/index.test.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import type { LanguagePlugin } from '@volar/language-core';
 import {
   type Language,
@@ -39,33 +38,11 @@ describe('ts-md-ls-core diagnostics', () => {
       ].join('\n'),
     );
 
-    const coreSrcDir = path.join(__dirname, '..', '..', 'core', 'src');
-    const coreDist = path.join(__dirname, '..', '..', 'core', 'dist');
-    fs.mkdirSync(coreDist, { recursive: true });
-    for (const file of fs.readdirSync(coreSrcDir)) {
-      if (!file.endsWith('.ts')) continue;
-      const src = path.join(coreSrcDir, file);
-      const dest = path.join(coreDist, file.replace(/\.ts$/, '.js'));
-      const source = fs.readFileSync(src, 'utf8');
-      const out = ts.transpileModule(source, {
-        compilerOptions: {
-          module: ts.ModuleKind.ESNext,
-          target: ts.ScriptTarget.ESNext,
-        },
-      });
-      const js = out.outputText.replace(
-        /from '(\.\/.+?)'/g,
-        (m, p) => `from '${p}.js'`,
-      );
-      fs.writeFileSync(dest, js);
-    }
-    const builtCore = path.join(coreDist, 'index.js');
     createTsMdPlugin = (await import('../src')).createTsMdPlugin;
   });
 
   afterAll(() => {
     fs.rmSync(dir, { recursive: true, force: true });
-    // keep coreDist to avoid conflicts across parallel tests
   });
 
   it('reports diagnostics across docs', async () => {

--- a/packages/unplugin/test/index.test.ts
+++ b/packages/unplugin/test/index.test.ts
@@ -17,33 +17,11 @@ describe('ts-md-unplugin', () => {
     );
     fs.writeFileSync(entry, "import '#./doc.ts.md:main';");
 
-    const coreSrcDir = path.join(__dirname, '..', '..', 'core', 'src');
-    const coreDist = path.join(__dirname, '..', '..', 'core', 'dist');
-    fs.mkdirSync(coreDist, { recursive: true });
-    for (const file of fs.readdirSync(coreSrcDir)) {
-      if (!file.endsWith('.ts')) continue;
-      const src = path.join(coreSrcDir, file);
-      const dest = path.join(coreDist, file.replace(/\.ts$/, '.js'));
-      const source = fs.readFileSync(src, 'utf8');
-      const result = require('typescript').transpileModule(source, {
-        compilerOptions: {
-          module: require('typescript').ModuleKind.ESNext,
-          target: require('typescript').ScriptTarget.ESNext,
-        },
-      });
-      const js = result.outputText.replace(
-        /from '(\.\/.+?)'/g,
-        (m, p) => `from '${p}.js'`,
-      );
-      fs.writeFileSync(dest, js);
-    }
-
     unpluginFactory = (await import('../src')).unplugin;
   });
 
   afterAll(() => {
     fs.rmSync(dir, { recursive: true, force: true });
-    // keep coreDist to avoid conflicts across parallel tests
   });
 
   it('loads chunk code', async () => {


### PR DESCRIPTION
## Summary
- update `.gitignore` to exclude turborepo cache
- clean up loader tests to use compiled core only
- load `ls-core` and unplugin modules from source

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68422fec54948325889d7e8c125e900b