### PR TITLE
Fix type errors by ordering builds and updating tests

### DIFF
--- a/packages/loader/test/index.test.ts
+++ b/packages/loader/test/index.test.ts
@@ -1,20 +1,12 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 describe('ts-md-loader', () => {
   const dir = path.join(__dirname, 'fixtures');
   const md = path.join(dir, 'doc.ts.md');
-  const loaderSrc = path.join(
-    __dirname,
-    '..',
-    '..',
-    '..',
-    'dist',
-    'loader',
-    'src',
-    'index.js',
-  );
+  const loaderSrc = path.join(__dirname, '..', 'dist', 'index.js');
   const builtLoader = path.join(dir, 'loader.mjs');
 
   beforeAll(() => {

--- a/packages/ls-core/test/index.test.ts
+++ b/packages/ls-core/test/index.test.ts
@@ -8,6 +8,7 @@ import {
   createLanguageService,
 } from '@volar/language-service';
 import ts from 'typescript';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { URI } from 'vscode-uri';
 import type { TsMdVirtualFile } from '../src';
 let createTsMdPlugin: typeof import('../src').createTsMdPlugin;

--- a/packages/unplugin/test/index.test.ts
+++ b/packages/unplugin/test/index.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { Plugin } from 'rollup';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 let unpluginFactory: typeof import('../src').unplugin;
 

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
+      "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
     "typecheck": {


### PR DESCRIPTION
## Summary
- ensure package build order by specifying dependencies in `turbo.json`
- update tests to import Vitest globals explicitly
- fix loader test path to compiled loader

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68442927b3608325996c47e6c055f9eb