### PR TITLE
loader パッケージで同ファイル参照をサポート

### DIFF
--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -4,9 +4,16 @@ export function resolveImport(
   specifier: string,
   importer: string,
 ): { absPath: string; chunk: string } | undefined {
-  const m = /^#([^:]+):(.+)$/.exec(specifier);
-  if (!m) return undefined;
-  const [, rel, chunk] = m;
-  const absPath = path.resolve(path.dirname(importer), rel);
-  return { absPath, chunk };
+  if (!specifier.startsWith('#')) return undefined;
+  const body = specifier.slice(1);
+  if (!body) return undefined;
+  if (body.includes(':')) {
+    const idx = body.indexOf(':');
+    const rel = body.slice(0, idx);
+    const chunk = body.slice(idx + 1);
+    if (!rel || !chunk) return undefined;
+    const absPath = path.resolve(path.dirname(importer), rel);
+    return { absPath, chunk };
+  }
+  return { absPath: importer, chunk: body };
 }

--- a/packages/core/test/resolver.test.ts
+++ b/packages/core/test/resolver.test.ts
@@ -10,4 +10,8 @@ describe('resolveImport', () => {
     const res = resolveImport('#../foo.ts.md:baz', '/a/b/c/app.ts.md');
     expect(res).toEqual({ absPath: '/a/b/foo.ts.md', chunk: 'baz' });
   });
+  it('resolves chunk in same file', () => {
+    const res = resolveImport('#qux', '/a/b/doc.ts.md');
+    expect(res).toEqual({ absPath: '/a/b/doc.ts.md', chunk: 'qux' });
+  });
 });

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -19,9 +19,16 @@ type Load = (
 const VIRTUAL_PREFIX = 'ts-md:';
 
 export const resolve: Resolve = async (specifier, context, defaultResolve) => {
-  const parentURL = context.parentURL
-    ? fileURLToPath(context.parentURL)
-    : undefined;
+  let parentURL: string | undefined;
+  if (context.parentURL) {
+    if (context.parentURL.startsWith(VIRTUAL_PREFIX)) {
+      const body = context.parentURL.slice(VIRTUAL_PREFIX.length);
+      const idx = body.lastIndexOf(':');
+      parentURL = body.slice(0, idx);
+    } else {
+      parentURL = fileURLToPath(context.parentURL);
+    }
+  }
   const specPath = specifier.startsWith('file:')
     ? fileURLToPath(specifier)
     : specifier;

--- a/packages/loader/test/index.test.ts
+++ b/packages/loader/test/index.test.ts
@@ -13,9 +13,18 @@ describe('ts-md-loader', () => {
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(
       md,
-      ['# Doc', '', '```ts main', "console.log('loader works')", '```'].join(
-        '\n',
-      ),
+      [
+        '# Doc',
+        '',
+        '```ts foo',
+        "export const msg = 'loader works'",
+        '```',
+        '',
+        '```ts main',
+        'import { msg } from "#foo"',
+        'console.log(msg)',
+        '```',
+      ].join('\n'),
     );
     const source = fs.readFileSync(loaderSrc, 'utf8');
     const loaderCode = source;
@@ -27,12 +36,9 @@ describe('ts-md-loader', () => {
   });
 
   it('runs markdown file', () => {
-    const out = execSync(
-      `node --import tsx/esm --loader ${builtLoader} ${md}`,
-      {
-        encoding: 'utf8',
-      },
-    );
+    const out = execSync(`node --loader ${builtLoader} ${md}`, {
+      encoding: 'utf8',
+    });
     expect(out.trim()).toBe('loader works');
   });
 });


### PR DESCRIPTION
## Summary
- loader が `#foo` のような同ファイル内参照を解決できるように resolver を拡張
- loader 側で親 URL が仮想スキームの場合でも解決可能に修正
- テストを `#foo` 参照を使う内容へ更新
- core の `resolveImport` とそのテストを更新

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684440e92380832589f58bd41ab5a303