### PR TITLE
Fix vscode build

### DIFF
--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "dist",
-    "composite": true,
+    "composite": false,
     "types": ["node", "vscode"],
     "baseUrl": ".",
     "rootDir": "../..",

--- a/packages/vscode/tsup.config.ts
+++ b/packages/vscode/tsup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   dts: true,
   target: 'node18',
   clean: true,
+  external: ['vscode'],
 });


### PR DESCRIPTION
## Summary
- mark `vscode` as external in VS Code extension build
- disable `composite` to avoid missing file errors in TS build

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6844c3523bd883258ff1f8ee30089ceb