### PR TITLE
Add CLI check error case

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     "commander": "^11",
     "fast-glob": "^3.3.3",
     "picocolors": "^1.0.0",
+    "vscode-uri": "^3.0.8",
     "typescript": "^5.5",
     "tsx": "^4",
     "@volar/language-service": "^2"

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,27 +1,99 @@
 import fs from 'node:fs';
-import { createTsMdPlugin as tsMdLanguagePlugin } from '@sterashima78/ts-md-ls-core';
-import { createLanguageService } from '@volar/language-service';
+import { parseChunks } from '@sterashima78/ts-md-core';
+import {
+  type TsMdVirtualFile,
+  createTsMdPlugin as tsMdLanguagePlugin,
+} from '@sterashima78/ts-md-ls-core';
+import type { LanguagePlugin } from '@volar/language-core';
+import {
+  type Language,
+  type SourceScript,
+  createLanguage,
+  createLanguageService,
+} from '@volar/language-service';
 import pc from 'picocolors';
 import ts from 'typescript';
+import { URI } from 'vscode-uri';
 import { expandGlobs } from '../utils/globs';
 
 export async function runCheck(globs: string[]) {
   const files = await expandGlobs(globs);
   if (!files.length) return console.log(pc.yellow('No .ts.md files found.'));
 
-  const docs = files.map((f) => ({
-    fileName: f,
-    languageId: 'ts-md',
-    snapshot: ts.ScriptSnapshot.fromString(
-      fs.readFileSync(f, 'utf8') as unknown as string,
-    ),
-  }));
+  const scripts = new Map<URI, SourceScript<URI>>();
+  const plugin = tsMdLanguagePlugin as unknown as LanguagePlugin<
+    URI,
+    TsMdVirtualFile
+  >;
+  let language!: Language<URI>;
+  language = createLanguage<URI>([plugin], scripts, (id) => {
+    if (scripts.has(id)) return;
+    let filePath: string;
+    if (typeof id === 'string') {
+      const m = /^#(.+):/.exec(id);
+      if (!m) return;
+      filePath = URI.parse(m[1]).fsPath;
+    } else {
+      filePath = id.fsPath;
+    }
+    const snapshot = ts.ScriptSnapshot.fromString(
+      fs.readFileSync(filePath, 'utf8') as unknown as string,
+    );
+    language.scripts.set(
+      typeof id === 'string' ? URI.parse(id) : id,
+      snapshot,
+      'ts-md',
+    );
+  });
 
-  const ls = createLanguageService(docs, { plugins: [tsMdLanguagePlugin], ts });
+  for (const file of files) {
+    const uri = URI.file(file);
+    const snapshot = ts.ScriptSnapshot.fromString(
+      fs.readFileSync(file, 'utf8') as unknown as string,
+    );
+    language.scripts.set(uri, snapshot, 'ts-md');
+  }
+
+  const ls = createLanguageService(language, [], { workspaceFolders: [] }, {});
 
   let errorCount = 0;
   for (const file of files) {
-    const diags = ls.doValidation(file);
+    const uri = URI.file(file);
+    language.scripts.get(uri);
+    let diags = await ls.getDiagnostics(uri);
+    if (!diags.length) {
+      diags = [];
+      const md = fs.readFileSync(file, 'utf8');
+      const dict = parseChunks(md, file);
+      for (const [chunk, code] of Object.entries(dict)) {
+        const name = `${file}:${chunk}.ts`;
+        const options = { noEmit: true, module: ts.ModuleKind.CommonJS };
+        const host = ts.createCompilerHost(options);
+        host.getSourceFile = (f, l) =>
+          f === name
+            ? ts.createSourceFile(f, code, l)
+            : ts.createSourceFile(f, fs.readFileSync(f, 'utf8'), l);
+        host.readFile = (f) => (f === name ? code : fs.readFileSync(f, 'utf8'));
+        host.fileExists = (f) => f === name || fs.existsSync(f);
+        const program = ts.createProgram([name], options, host);
+        const extra = ts.getPreEmitDiagnostics(program).map((d) => {
+          const sf = program.getSourceFile(name);
+          return {
+            message: ts.flattenDiagnosticMessageText(d.messageText, '\n'),
+            range: {
+              start: sf?.getLineAndCharacterOfPosition(d.start ?? 0) ?? {
+                line: 0,
+                character: 0,
+              },
+              end: sf?.getLineAndCharacterOfPosition(
+                (d.start ?? 0) + (d.length ?? 0),
+              ) ?? { line: 0, character: 0 },
+            },
+          };
+        });
+        diags.push(...extra);
+      }
+    }
     for (const d of diags) {
       console.error(
         `${pc.red('error')} ${file}:${d.range.start.line + 1}:${d.range.start.character + 1} ${d.message}`,

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     '@sterashima78/ts-md-ls-core',
     '@sterashima78/ts-md-core',
     '@sterashima78/ts-md-loader',
+    'vscode-uri',
     'tsx/esm',
   ],
 });

--- a/packages/e2e/test/fixtures/error.ts.md
+++ b/packages/e2e/test/fixtures/error.ts.md
@@ -1,0 +1,5 @@
+# Error fixture
+
+```ts main
+const str: string = 123
+```

--- a/packages/e2e/test/index.test.ts
+++ b/packages/e2e/test/index.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const fixture = path.join(__dirname, 'fixtures', 'app.ts.md');
+const bad = path.join(__dirname, 'fixtures', 'error.ts.md');
 
 const pkgRoot = path.join(__dirname, '..');
 
@@ -25,4 +26,24 @@ describe('e2e', () => {
     const out = await fs.readFile(tmp, 'utf8');
     expect(out.trim()).toBe('e2e success');
   });
+
+  it('checks markdown via CLI', () => {
+    execSync(`pnpm exec tsmd check ${fixture}`, { cwd: pkgRoot });
+  }, 20000);
+
+  it('fails to check invalid markdown via CLI', () => {
+    try {
+      execSync(`pnpm exec tsmd check ${bad}`, {
+        cwd: pkgRoot,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+      throw new Error('expected failure');
+    } catch (err) {
+      const e = err as { stderr: string };
+      expect(e.stderr).toMatch(
+        "Type 'number' is not assignable to type 'string'",
+      );
+    }
+  }, 20000);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       typescript:
         specifier: ^5.5
         version: 5.8.3
+      vscode-uri:
+        specifier: ^3.0.8
+        version: 3.1.0
     devDependencies:
       tsup:
         specifier: ^8


### PR DESCRIPTION
## Summary
- extend `runCheck` to fall back to TypeScript diagnostics when Volar returns none
- add fixture with a type error for e2e
- cover success and failure cases in e2e tests
- validate error message from the check command

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6844b34bf03c8325a07c8b3ca17cb1c3