### PR TITLE
Remove unused dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,10 +20,7 @@
     "commander": "^11",
     "fast-glob": "^3.3.3",
     "picocolors": "^1.0.0",
-    "vscode-uri": "^3.0.8",
-    "typescript": "^5.5",
-    "tsx": "^4",
-    "@volar/language-service": "^2"
+    "tsx": "^4"
   },
   "devDependencies": {
     "tsup": "^8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "remark-parse": "^11.0.0",
     "unified": "^11.0.0",
-    "unist-util-visit": "^5.0.0",
-    "mdast": "^3.0.0"
+    "unist-util-visit": "^5.0.0"
   }
 }

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -14,7 +14,6 @@
     "@volar/monaco": "^2.4.11",
     "monaco-editor": "^0.50.0",
     "react": "^18.3.0",
-    "react-dom": "^18.3.0",
     "@monaco-editor/react": "^4.7.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       '@sterashima78/ts-md-ls-core':
         specifier: workspace:*
         version: link:../ls-core
-      '@volar/language-service':
-        specifier: ^2
-        version: 2.4.14
       commander:
         specifier: ^11
         version: 11.1.0
@@ -68,12 +65,6 @@ importers:
       tsx:
         specifier: ^4
         version: 4.19.4
-      typescript:
-        specifier: ^5.5
-        version: 5.8.3
-      vscode-uri:
-        specifier: ^3.0.8
-        version: 3.1.0
     devDependencies:
       tsup:
         specifier: ^8
@@ -84,9 +75,6 @@ importers:
 
   packages/core:
     dependencies:
-      mdast:
-        specifier: ^3.0.0
-        version: 3.0.0
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
@@ -144,9 +132,6 @@ importers:
       react:
         specifier: ^18.3.0
         version: 18.3.1
-      react-dom:
-        specifier: ^18.3.0
-        version: 18.3.1(react@18.3.1)
     devDependencies:
       '@testing-library/react':
         specifier: ^14.1.2
@@ -1656,10 +1641,6 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
-
-  mdast@3.0.0:
-    resolution: {integrity: sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==}
-    deprecated: '`mdast` was renamed to `remark`'
 
   mdurl@1.0.1:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
@@ -4108,8 +4089,6 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-
-  mdast@3.0.0: {}
 
   mdurl@1.0.1: {}
 


### PR DESCRIPTION
## Summary
- 不要な依存を削除しました
  - CLI パッケージから `typescript` `vscode-uri` `@volar/language-service` を削除
  - core パッケージから `mdast` を削除
  - monaco パッケージから `react-dom` を削除

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6844cc32c9508325b967219eddf1e80c