### PR TITLE
Add loader E2E test

### DIFF
--- a/packages/e2e/test/loader.test.ts
+++ b/packages/e2e/test/loader.test.ts
@@ -1,0 +1,37 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const loaderPath = require.resolve('@sterashima78/ts-md-loader');
+
+describe('loader e2e', () => {
+  it('runs markdown via Node loader', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'loader-e2e-'));
+    const md = path.join(dir, 'doc.ts.md');
+    fs.writeFileSync(
+      md,
+      [
+        '# Doc',
+        '',
+        '```ts foo',
+        "export const msg = 'loader e2e success'",
+        '```',
+        '',
+        '```ts main',
+        'import { msg } from "#foo"',
+        'console.log(msg)',
+        '```',
+      ].join('\n'),
+    );
+    const out = execSync(`node --loader ${loaderPath} ${md}`, {
+      cwd: dir,
+      encoding: 'utf8',
+    });
+    expect(out.trim()).toBe('loader e2e success');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- e2e テストで loader パッケージを実際に指定して実行

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6844cfcf58188325b99de48592da2e66