### PR TITLE
Add multi block check cases

### DIFF
--- a/packages/e2e/test/fixtures/multi-error.ts.md
+++ b/packages/e2e/test/fixtures/multi-error.ts.md
@@ -1,0 +1,11 @@
+# Multi Error
+
+```ts foo
+export const num: number = 123
+```
+
+```ts main
+import { num } from '#foo'
+const str: string = num
+console.log(str)
+```

--- a/packages/e2e/test/fixtures/multi.ts.md
+++ b/packages/e2e/test/fixtures/multi.ts.md
@@ -1,0 +1,10 @@
+# Multi
+
+```ts foo
+export const msg = 'multi success'
+```
+
+```ts main
+import { msg } from '#foo'
+console.log(msg)
+```

--- a/packages/e2e/test/index.test.ts
+++ b/packages/e2e/test/index.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from 'vitest';
 
 const fixture = path.join(__dirname, 'fixtures', 'app.ts.md');
 const bad = path.join(__dirname, 'fixtures', 'error.ts.md');
+const multi = path.join(__dirname, 'fixtures', 'multi.ts.md');
+const multiBad = path.join(__dirname, 'fixtures', 'multi-error.ts.md');
 
 const pkgRoot = path.join(__dirname, '..');
 
@@ -34,6 +36,26 @@ describe('e2e', () => {
   it('fails to check invalid markdown via CLI', () => {
     try {
       execSync(`pnpm exec tsmd check ${bad}`, {
+        cwd: pkgRoot,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+      throw new Error('expected failure');
+    } catch (err) {
+      const e = err as { stderr: string };
+      expect(e.stderr).toMatch(
+        "Type 'number' is not assignable to type 'string'",
+      );
+    }
+  }, 20000);
+
+  it('checks markdown with multiple code blocks', () => {
+    execSync(`pnpm exec tsmd check ${multi}`, { cwd: pkgRoot });
+  }, 20000);
+
+  it('fails to check invalid markdown with multiple code blocks', () => {
+    try {
+      execSync(`pnpm exec tsmd check ${multiBad}`, {
         cwd: pkgRoot,
         encoding: 'utf8',
         stdio: 'pipe',


### PR DESCRIPTION
## Summary
- add fixture with cross-block import
- allow diagnostics resolver to handle `#` imports
- update e2e check tests with new fixture
- fix multi block fixture to use `#foo`
- refine error fixture to import number as string

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6844d80b6454832598d7a363ee040e1e