### PR TITLE
Add cross-document check e2e tests

### DIFF
--- a/packages/e2e/test/fixtures/cross-dep.ts.md
+++ b/packages/e2e/test/fixtures/cross-dep.ts.md
@@ -1,0 +1,5 @@
+# Cross Dep
+
+```ts foo
+export const val = 'cross value'
+```

--- a/packages/e2e/test/fixtures/cross-error-dep.ts.md
+++ b/packages/e2e/test/fixtures/cross-error-dep.ts.md
@@ -1,0 +1,5 @@
+# Cross Error Dep
+
+```ts foo
+export const num = 123
+```

--- a/packages/e2e/test/fixtures/cross-error-main.ts.md
+++ b/packages/e2e/test/fixtures/cross-error-main.ts.md
@@ -1,0 +1,7 @@
+# Cross Error Main
+
+```ts main
+import { num } from '#./cross-error-dep.ts.md:foo'
+const str: string = num
+console.log(str)
+```

--- a/packages/e2e/test/fixtures/cross-main.ts.md
+++ b/packages/e2e/test/fixtures/cross-main.ts.md
@@ -1,0 +1,7 @@
+# Cross Main
+
+```ts main
+import { val } from '#./cross-dep.ts.md:foo'
+const str: string = val
+console.log(str)
+```

--- a/packages/e2e/test/index.test.ts
+++ b/packages/e2e/test/index.test.ts
@@ -8,6 +8,10 @@ const fixture = path.join(__dirname, 'fixtures', 'app.ts.md');
 const bad = path.join(__dirname, 'fixtures', 'error.ts.md');
 const multi = path.join(__dirname, 'fixtures', 'multi.ts.md');
 const multiBad = path.join(__dirname, 'fixtures', 'multi-error.ts.md');
+const crossMain = path.join(__dirname, 'fixtures', 'cross-main.ts.md');
+const crossDep = path.join(__dirname, 'fixtures', 'cross-dep.ts.md');
+const crossErrMain = path.join(__dirname, 'fixtures', 'cross-error-main.ts.md');
+const crossErrDep = path.join(__dirname, 'fixtures', 'cross-error-dep.ts.md');
 
 const pkgRoot = path.join(__dirname, '..');
 
@@ -56,6 +60,26 @@ describe('e2e', () => {
   it('fails to check invalid markdown with multiple code blocks', () => {
     try {
       execSync(`pnpm exec tsmd check ${multiBad}`, {
+        cwd: pkgRoot,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+      throw new Error('expected failure');
+    } catch (err) {
+      const e = err as { stderr: string };
+      expect(e.stderr).toMatch(
+        "Type 'number' is not assignable to type 'string'",
+      );
+    }
+  }, 20000);
+
+  it('checks markdown across documents', () => {
+    execSync(`pnpm exec tsmd check ${crossMain} ${crossDep}`, { cwd: pkgRoot });
+  }, 20000);
+
+  it('fails to check invalid markdown across documents', () => {
+    try {
+      execSync(`pnpm exec tsmd check ${crossErrMain} ${crossErrDep}`, {
         cwd: pkgRoot,
         encoding: 'utf8',
         stdio: 'pipe',


### PR DESCRIPTION
## Summary
- add cross-dep fixtures for e2e tests
- check CLI with imports across docs
- ensure failure case for incorrect types

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6844f70adc7c832583ff19da0a6dc3f7