### PR TITLE
VSCodeパッケージ用のセットアップスクリプト追加

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "download": "tsx scripts/download.ts"
   },
   "dependencies": {
     "@sterashima78/ts-md-ls-core": "workspace:*",

--- a/packages/vscode/scripts/download.ts
+++ b/packages/vscode/scripts/download.ts
@@ -1,0 +1,11 @@
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+
+async function main() {
+  const path = await downloadAndUnzipVSCode('stable');
+  console.log(`Downloaded VS Code to: ${path}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- vscode パッケージに VSCode をダウンロードするスクリプトを追加
- npm script `download` を追加

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6846055a2494832587b1bad6c2c25e7f