### PR TITLE
Fix language server diagnostics

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -11,7 +11,8 @@
     "vitest": "^1.5.1",
     "@vscode/test-electron": "^2.4.2",
     "@sterashima78/ts-md-cli": "workspace:*",
-    "@sterashima78/ts-md-loader": "workspace:*"
+    "@sterashima78/ts-md-loader": "workspace:*",
+    "@sterashima78/ts-md-vscode": "workspace:*"
   },
   "devDependencies": {
     "@types/vscode": "^1.89.0",

--- a/packages/e2e/src/runTest.ts
+++ b/packages/e2e/src/runTest.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { runTests } from '@vscode/test-electron';
 import { test } from 'vitest';
@@ -6,12 +7,19 @@ const ROOT = path.resolve(__dirname, '../../../');
 const EXT = path.resolve(ROOT, 'packages/vscode');
 const TESTS = path.resolve(__dirname, 'suite/index.cjs');
 const WS = path.resolve(__dirname, 'fixtures/error-project');
+const VSCODE = path.resolve(ROOT, '.vscode-test', 'VSCode-linux-x64', 'code');
 
-test.skip('vscode extension e2e', async () => {
-  await runTests({
-    version: 'stable',
+test('vscode extension e2e', async () => {
+  const options: Parameters<typeof runTests>[0] = {
     extensionDevelopmentPath: EXT,
     extensionTestsPath: TESTS,
     launchArgs: [WS, '--disable-workspace-trust'],
-  });
+    reuseMachineInstall: true,
+  };
+  if (fs.existsSync(VSCODE)) {
+    options.vscodeExecutablePath = VSCODE;
+  } else {
+    options.version = 'stable';
+  }
+  await runTests(options);
 });

--- a/packages/e2e/src/suite/extension.test.ts
+++ b/packages/e2e/src/suite/extension.test.ts
@@ -24,7 +24,7 @@ describe('TS-MD diagnostics', () => {
   });
 });
 
-async function waitForDiagnostics(uri: vscode.Uri, timeout = 8000) {
+async function waitForDiagnostics(uri: vscode.Uri, timeout = 20000) {
   const t0 = Date.now();
   while (Date.now() - t0 < timeout) {
     if (vscode.languages.getDiagnostics(uri).length) return;

--- a/packages/e2e/src/suite/index.cjs
+++ b/packages/e2e/src/suite/index.cjs
@@ -1,6 +1,6 @@
 const vscode = require('vscode');
 
-async function waitForDiagnostics(uri, timeout = 8000) {
+async function waitForDiagnostics(uri, timeout = 20000) {
   const t0 = Date.now();
   while (Date.now() - t0 < timeout) {
     if (vscode.languages.getDiagnostics(uri).length) return;
@@ -15,6 +15,7 @@ exports.run = async () => {
   const bad = vscode.Uri.joinPath(ws.uri, 'bad.ts.md');
   const doc = await vscode.workspace.openTextDocument(bad);
   await vscode.window.showTextDocument(doc);
+  console.log('languageId', doc.languageId);
   await waitForDiagnostics(doc.uri);
   const diags = vscode.languages.getDiagnostics(doc.uri);
   const has = diags.some((d) => /Argument of type/.test(d.message));

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -16,7 +16,9 @@
     "@volar/language-server": "^2.4.14",
     "vscode-languageclient": "^9.0.1",
     "@volar/language-core": "^2.4.14",
-    "vscode-uri": "^3.0.8"
+    "vscode-uri": "^3.0.8",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.1"
   },
   "devDependencies": {
     "@types/vscode": "^1.89.0",
@@ -32,6 +34,7 @@
         "id": "ts-md",
         "aliases": ["TypeScript Markdown", "ts-md"],
         "extensions": [".ts.md"],
+        "filenamePatterns": ["*.ts.md"],
         "configuration": "./dist/language-configuration.json"
       }
     ],

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -11,7 +11,7 @@ import { registerCommands } from './commands';
 let client: LanguageClient;
 
 export async function activate(ctx: vscode.ExtensionContext) {
-  const serverModule = ctx.asAbsolutePath('dist/server.js');
+  const serverModule = ctx.asAbsolutePath('dist/server/server.js');
 
   const serverOptions: ServerOptions = {
     run: { module: serverModule, transport: TransportKind.stdio },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@sterashima78/ts-md-loader':
         specifier: workspace:*
         version: link:../loader
+      '@sterashima78/ts-md-vscode':
+        specifier: workspace:*
+        version: link:../vscode
       '@vscode/test-electron':
         specifier: ^2.4.2
         version: 2.5.2
@@ -188,6 +191,12 @@ importers:
       vscode-languageclient:
         specifier: ^9.0.1
         version: 9.0.1
+      vscode-languageserver:
+        specifier: ^9.0.1
+        version: 9.0.1
+      vscode-languageserver-textdocument:
+        specifier: ^1.0.1
+        version: 1.0.12
       vscode-uri:
         specifier: ^3.0.8
         version: 3.1.0


### PR DESCRIPTION
## Summary
- VSCode 向け言語サーバーを単純化し、ドキュメント変更時に `collectDiagnostics` を実行
- LSP 実装に必要な `vscode-languageserver` 系パッケージを追加
- `.vscode-test` が無い環境では `stable` を使うよう e2e テストを修正

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68481c835f4083258d30b9a4db0cf80b