### PR TITLE
Add build step to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           version: 9
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
+      - name: Build packages
+        run: pnpm build
       - name: Publish packages
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- run `pnpm build` before publishing packages so built files are included

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849e3b1f20c8325907ab9a579cf44df