### PR TITLE
Fix changeset version script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,12 @@ jobs:
           version: 9
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
-      - name: Build packages
-        run: pnpm build
       - name: Publish packages
         id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm release
-          version: pnpm version-packages && pnpm biome format . --write
+          version: pnpm version-packages
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "typecheck": "turbo run typecheck",
     "lint": "biome check",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && pnpm biome format . --write",
+    "prerelease": "turbo run build",
     "release": "pnpm changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- fix release.yml to call `pnpm version-packages` only
- make `pnpm version-packages` run formatting
- build packages only during release

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849f556e13083258dba89cb79cbd026