### PR TITLE
不要なCJSビルドを削除

### DIFF
--- a/.changeset/unplugin-no-cjs.md
+++ b/.changeset/unplugin-no-cjs.md
@@ -1,0 +1,4 @@
+---
+"@sterashima78/ts-md-unplugin": patch
+---
+CJS ビルドを廃止しました。

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sterashima78/ts-md-unplugin",
   "version": "0.0.2",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -12,7 +13,7 @@
   },
   "files": ["dist"],
   "scripts": {
-    "build": "tsup src/index.ts src/vite.ts src/rollup.ts src/webpack.ts src/esbuild.ts --format esm,cjs --dts",
+    "build": "tsup src/index.ts src/vite.ts src/rollup.ts src/webpack.ts src/esbuild.ts --format esm --dts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/unplugin/tsup.config.ts
+++ b/packages/unplugin/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     'src/webpack.ts',
     'src/esbuild.ts',
   ],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
 });


### PR DESCRIPTION
## Summary
- vscode 以外の CJS ビルドを廃止
- unplugin パッケージのみ変更し、changeset を追加

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849ffac29dc8325843b3552922d1647