### PR TITLE
Add skipLibCheck and static unplugin import

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": false
+    "declaration": false,
+    "skipLibCheck": true
   },
   "include": ["src"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,9 @@
     "unified": "^11.0.0",
     "unist-util-visit": "^5.0.0"
   },
+  "devDependencies": {
+    "@sterashima78/ts-md-unplugin": "^0.0.2"
+  },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,3 +1,4 @@
+import plugin from '@sterashima78/ts-md-unplugin/esbuild';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -6,4 +7,5 @@ export default defineConfig({
   format: ['esm'],
   clean: true,
   target: 'node18',
+  esbuildPlugins: [plugin],
 });

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "skipLibCheck": true
   },
   "include": ["src/**/*"]
 }

--- a/packages/loader/tsconfig.json
+++ b/packages/loader/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
 }

--- a/packages/ls-core/tsconfig.json
+++ b/packages/ls-core/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "compilerOptions": {
     "module": "nodenext",
-    "moduleResolution": "nodenext"
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true
   }
 }

--- a/packages/monaco/tsconfig.json
+++ b/packages/monaco/tsconfig.json
@@ -5,7 +5,8 @@
     "baseUrl": ".",
     "paths": {
       "@sterashima78/ts-md-ls-core": ["../ls-core/src"]
-    }
+    },
+    "skipLibCheck": true
   },
   "include": ["src", "src/types.d.ts"]
 }

--- a/packages/unplugin/tsconfig.json
+++ b/packages/unplugin/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "skipLibCheck": true
+  }
 }

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -9,7 +9,8 @@
     "rootDir": "../..",
     "paths": {
       "@sterashima78/ts-md-ls-core": ["../ls-core/src"]
-    }
+    },
+    "skipLibCheck": true
   },
   "include": ["src", "../ls-core/src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,10 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
+    devDependencies:
+      '@sterashima78/ts-md-unplugin':
+        specifier: ^0.0.2
+        version: 0.0.2
 
   packages/e2e:
     dependencies:
@@ -830,6 +834,12 @@ packages:
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@sterashima78/ts-md-core@0.0.2':
+    resolution: {integrity: sha512-vBRJ/ChiYfY3R4yLkXRtKlKFF3SpoddEvNNITAnNxSPAz0diyK/F0YvcRVbzWqiz3Qp0d7jyTJmiTwNldKOvig==, tarball: https://npm.pkg.github.com/download/@sterashima78/ts-md-core/0.0.2/cdaa1b8542826886f6ba1dbe6fe8ccf47debd94d}
+
+  '@sterashima78/ts-md-unplugin@0.0.2':
+    resolution: {integrity: sha512-sPSxN8JuCSaEWP4ygENttvZUD9Jq5gWu3/C1GyxAhLqUaeM4KkjX8gLCOe/mqZmCIUpboQFq5agCYzHGZlL6Wg==, tarball: https://npm.pkg.github.com/download/@sterashima78/ts-md-unplugin/0.0.2/10737c14e5639a2204fd0f7bd44a1c797d692896}
 
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -3507,6 +3517,20 @@ snapshots:
     optional: true
 
   '@sinclair/typebox@0.27.8': {}
+
+  '@sterashima78/ts-md-core@0.0.2':
+    dependencies:
+      remark-parse: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sterashima78/ts-md-unplugin@0.0.2':
+    dependencies:
+      '@sterashima78/ts-md-core': 0.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@testing-library/dom@9.3.4':
     dependencies:


### PR DESCRIPTION
## Summary
- tsconfigファイル全てに`skipLibCheck: true`を追加
- coreパッケージのtsup設定で`@sterashima78/ts-md-unplugin`を静的インポート

## Testing
- `pnpm lint`
- `pnpm typecheck` *(失敗)*
- `pnpm test` *(失敗)*

------
https://chatgpt.com/codex/tasks/task_e_684a0424e51c832586e15f586dc82329