### PR TITLE
Add ts-md-unplugin to core build

### DIFF
--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write
       pull-requests: write

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,5 +21,8 @@
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"
+  },
+  "devDependencies": {
+    "@sterashima78/ts-md-unplugin": "^0.0.3"
   }
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,3 +1,4 @@
+import tsMd from '@sterashima78/ts-md-unplugin/esbuild';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -6,4 +7,5 @@ export default defineConfig({
   format: ['esm'],
   clean: true,
   target: 'node18',
+  esbuildPlugins: [tsMd],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,10 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
+    devDependencies:
+      '@sterashima78/ts-md-unplugin':
+        specifier: ^0.0.3
+        version: 0.0.3
 
   packages/e2e:
     dependencies:
@@ -830,6 +834,12 @@ packages:
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+
+  '@sterashima78/ts-md-core@0.0.2':
+    resolution: {integrity: sha512-vBRJ/ChiYfY3R4yLkXRtKlKFF3SpoddEvNNITAnNxSPAz0diyK/F0YvcRVbzWqiz3Qp0d7jyTJmiTwNldKOvig==, tarball: https://npm.pkg.github.com/download/@sterashima78/ts-md-core/0.0.2/cdaa1b8542826886f6ba1dbe6fe8ccf47debd94d}
+
+  '@sterashima78/ts-md-unplugin@0.0.3':
+    resolution: {integrity: sha512-qUON6r089aClfiKe0uYnYmQ+nb8oUX2jQWeRVKcUBq7pM+dbki6pFzj2gTCZK3tmhVO6Qh5uJUcvmUZmgMxEDw==, tarball: https://npm.pkg.github.com/download/@sterashima78/ts-md-unplugin/0.0.3/1284ea95b8ac62f32bdddf7232721690ca1c934b}
 
   '@testing-library/dom@9.3.4':
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
@@ -3507,6 +3517,23 @@ snapshots:
     optional: true
 
   '@sinclair/typebox@0.27.8': {}
+
+  '@sterashima78/ts-md-core@0.0.2':
+    dependencies:
+      remark-parse: 11.0.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sterashima78/ts-md-unplugin@0.0.3':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.41.1)
+      '@sterashima78/ts-md-core': 0.0.2
+      rollup: 4.41.1
+      unplugin: 2.3.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@testing-library/dom@9.3.4':
     dependencies:


### PR DESCRIPTION
## Summary
- install `@sterashima78/ts-md-unplugin` in `core`
- apply the plugin in `core`'s build config

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684a9d820b9083259fdc902d07f89227