### PR TITLE
Fix esbuild handling in unplugin

### DIFF
--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -7,57 +7,67 @@ export interface Options {
   include?: RegExp;
 }
 
-export const unplugin = createUnplugin(
-  ({ include = /\.ts\.md$/ }: Options | undefined = {}) => {
-    const filter = createFilter(include);
-    const cache = new Map<string, Record<string, string>>();
+export const unplugin = createUnplugin((options: Options | undefined, meta) => {
+  const { include = /\.ts\.md$/ } = options ?? {};
+  const filter = createFilter(include);
+  const cache = new Map<string, Record<string, string>>();
+  const isEsbuild = meta.framework === 'esbuild';
 
-    return {
-      name: 'ts-md',
-      enforce: 'pre',
-      resolveId(id, importer) {
-        if (!id.startsWith('#') || !importer) return;
-        const info = resolveImport(id, importer);
-        if (!info) return;
-        const absPath = info.absPath;
-        const chunk = info.chunk;
-        return `\0ts-md:${absPath}?c=${chunk}`;
-      },
-      async load(id) {
-        if (!filter(id)) {
-          if (id.startsWith('\0ts-md:')) {
-            const m = id.match(/^\0ts-md:(.+?)\?c=(.+)$/);
-            if (!m) return;
-            const [, abs, chunk] = m;
-            const dict = cache.get(abs) ?? (await parseFile(abs));
-            return dict[chunk];
-          }
-          return;
-        }
-        const dict = await parseFile(id);
-        return Object.keys(dict)
-          .filter((c) => /^(main|index)$/.test(c))
-          .map((c) => `import '#${id}:${c}'`)
-          .join('\n');
-      },
-      async watchChange(id) {
-        if (filter(id)) await parseFile(id, true);
-      },
-    };
-
-    async function parseFile(file: string, force = false) {
-      const cached = cache.get(file);
-      if (cached && !force) return cached;
-      const md = await fs.readFile(file, 'utf8');
-      const chunks = parseChunks(md, file);
-      const dict: Record<string, string> = {};
-      for (const [name, chunk] of Object.entries(chunks)) {
-        dict[name] = chunk;
+  return {
+    name: 'ts-md',
+    enforce: 'pre',
+    resolveId(id, importer) {
+      if (!id.startsWith('#') || !importer) return;
+      const info = resolveImport(id, importer);
+      if (!info) return;
+      const absPath = info.absPath;
+      const chunk = info.chunk;
+      if (isEsbuild) {
+        return { id: absPath, namespace: 'ts-md', suffix: `?c=${chunk}` };
       }
-      cache.set(file, dict);
-      return dict;
+      return `\0ts-md:${absPath}?c=${chunk}`;
+    },
+    async load(id) {
+      if (!filter(id)) {
+        if (id.startsWith('\0ts-md:')) {
+          const m = id.match(/^\0ts-md:(.+?)\?c=(.+)$/);
+          if (!m) return;
+          const [, abs, chunk] = m;
+          const dict = cache.get(abs) ?? (await parseFile(abs));
+          return dict[chunk];
+        }
+        if (isEsbuild) {
+          const m = id.match(/^(.+?)\?c=(.+)$/);
+          if (!m) return;
+          const [, abs, chunk] = m;
+          const dict = cache.get(abs) ?? (await parseFile(abs));
+          return dict[chunk];
+        }
+        return;
+      }
+      const dict = await parseFile(id);
+      return Object.keys(dict)
+        .filter((c) => /^(main|index)$/.test(c))
+        .map((c) => `import '#${id}:${c}'`)
+        .join('\n');
+    },
+    async watchChange(id) {
+      if (filter(id)) await parseFile(id, true);
+    },
+  };
+
+  async function parseFile(file: string, force = false) {
+    const cached = cache.get(file);
+    if (cached && !force) return cached;
+    const md = await fs.readFile(file, 'utf8');
+    const chunks = parseChunks(md, file);
+    const dict: Record<string, string> = {};
+    for (const [name, chunk] of Object.entries(chunks)) {
+      dict[name] = chunk;
     }
-  },
-);
+    cache.set(file, dict);
+    return dict;
+  }
+});
 
 export default unplugin;


### PR DESCRIPTION
## Summary
- fix esbuild id handling in `@sterashima78/ts-md-unplugin`
- adapt `resolveId` and `load` when used via esbuild

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab4e6fcd88325ad98f1ff8c1f507b