### PR TITLE
Fix ts-md-unplugin dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@sterashima78/ts-md-unplugin": "^0.0.4"
+    "@sterashima78/ts-md-unplugin": "0.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 5.0.0
     devDependencies:
       '@sterashima78/ts-md-unplugin':
-        specifier: ^0.0.3
+        specifier: 0.0.3
         version: 0.0.3
 
   packages/e2e:


### PR DESCRIPTION
## Summary
- pin ts-md-unplugin dev dependency to version 0.0.3
- update lockfile

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684ac82aa0088325b56ed35cc8db0fa9