### PR TITLE
Add sandbox build for import-example

### DIFF
--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -8,3 +8,11 @@ pnpm -F @sterashima78/ts-md-sandbox build:tsup
 pnpm -F @sterashima78/ts-md-sandbox build:vite
 pnpm -F @sterashima78/ts-md-sandbox start
 ```
+
+## ts ファイルから ts.md をインポートする例
+
+`src/import-example.ts` では `.ts` ファイルから `.ts.md` ファイルのチャンクをインポートしています。
+
+```ts
+import '#./app.ts.md:foo'
+```

--- a/packages/sandbox/src/import-example.ts
+++ b/packages/sandbox/src/import-example.ts
@@ -1,0 +1,1 @@
+import '#./app.ts.md:foo';

--- a/packages/sandbox/tsup.config.ts
+++ b/packages/sandbox/tsup.config.ts
@@ -2,7 +2,7 @@ import tsMd from '@sterashima78/ts-md-unplugin/esbuild';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: { app: 'src/index.ts' },
+  entry: { app: 'src/index.ts', importExample: 'src/import-example.ts' },
   format: ['esm'],
   target: 'node18',
   clean: true,

--- a/packages/sandbox/vite.config.ts
+++ b/packages/sandbox/vite.config.ts
@@ -5,9 +5,11 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      entry: {
+        app: resolve(__dirname, 'src/index.ts'),
+        importExample: resolve(__dirname, 'src/import-example.ts'),
+      },
       formats: ['es'],
-      fileName: 'app',
     },
     outDir: 'dist/vite',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- sandbox のビルド設定を更新して `import-example.ts` も出力

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm -F @sterashima78/ts-md-sandbox build`


------
https://chatgpt.com/codex/tasks/task_e_684b3cae66bc83258f22ecb8d05d7044