### PR TITLE
Add type import example to sandbox

### DIFF
--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -7,6 +7,7 @@ pnpm -F @sterashima78/ts-md-sandbox build
 pnpm -F @sterashima78/ts-md-sandbox build:tsup
 pnpm -F @sterashima78/ts-md-sandbox build:vite
 pnpm -F @sterashima78/ts-md-sandbox start
+pnpm -F @sterashima78/ts-md-sandbox typecheck
 ```
 
 ## ts ファイルから ts.md をインポートする例
@@ -15,4 +16,13 @@ pnpm -F @sterashima78/ts-md-sandbox start
 
 ```ts
 import '#./app.ts.md:foo'
+```
+
+## ts.md ファイルから type インポートする例
+
+`src/type-import-example.ts` では `.ts.md` ファイルから型のみを
+インポートしています。
+
+```ts
+import type { Greeter } from '#./types.ts.md:greeter'
 ```

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -8,10 +8,13 @@
     "build:tsup": "tsup",
     "build:vite": "vite build",
     "build": "pnpm build:vite && pnpm build:tsup",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsmd check 'src/**/*.ts.md'",
     "start": "node dist/tsup/app.js"
   },
   "dependencies": {
     "@sterashima78/ts-md-unplugin": "workspace:*"
+  },
+  "devDependencies": {
+    "@sterashima78/ts-md-cli": "workspace:*"
   }
 }

--- a/packages/sandbox/src/type-import-example.ts
+++ b/packages/sandbox/src/type-import-example.ts
@@ -1,0 +1,9 @@
+import type { Greeter } from '#./types.ts.md:greeter';
+
+const greeter: Greeter = {
+  greet(message) {
+    console.log(message);
+  },
+};
+
+greeter.greet('hello type import');

--- a/packages/sandbox/src/types.ts.md
+++ b/packages/sandbox/src/types.ts.md
@@ -1,0 +1,7 @@
+# Types Example
+
+```ts greeter
+export interface Greeter {
+  greet(message: string): void
+}
+```

--- a/packages/sandbox/tsup.config.ts
+++ b/packages/sandbox/tsup.config.ts
@@ -2,7 +2,11 @@ import tsMd from '@sterashima78/ts-md-unplugin/esbuild';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: { app: 'src/index.ts', importExample: 'src/import-example.ts' },
+  entry: {
+    app: 'src/index.ts',
+    importExample: 'src/import-example.ts',
+    typeImportExample: 'src/type-import-example.ts',
+  },
   format: ['esm'],
   target: 'node18',
   clean: true,

--- a/packages/sandbox/vite.config.ts
+++ b/packages/sandbox/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       entry: {
         app: resolve(__dirname, 'src/index.ts'),
         importExample: resolve(__dirname, 'src/import-example.ts'),
+        typeImportExample: resolve(__dirname, 'src/type-import-example.ts'),
       },
       formats: ['es'],
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,10 @@ importers:
       '@sterashima78/ts-md-unplugin':
         specifier: workspace:*
         version: link:../unplugin
+    devDependencies:
+      '@sterashima78/ts-md-cli':
+        specifier: workspace:*
+        version: link:../cli
 
   packages/unplugin:
     dependencies:


### PR DESCRIPTION
## Summary
- sandboxに型のみをインポートする例を追加
- tsup/vite設定を更新
- sandboxのtypecheckをCLIのcheckコマンドに変更
- sandboxで@sterashima78/ts-md-cliを依存に追加し、tsmdコマンドを利用

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684b43274b708325982e2619918caa38