### PR TITLE
Add vitest example for sandbox

### DIFF
--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -8,6 +8,7 @@ pnpm -F @sterashima78/ts-md-sandbox build:tsup
 pnpm -F @sterashima78/ts-md-sandbox build:vite
 pnpm -F @sterashima78/ts-md-sandbox start
 pnpm -F @sterashima78/ts-md-sandbox typecheck
+pnpm -F @sterashima78/ts-md-sandbox test
 ```
 
 ## ts ファイルから ts.md をインポートする例

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -9,12 +9,14 @@
     "build:vite": "vite build",
     "build": "pnpm build:vite && pnpm build:tsup",
     "typecheck": "tsmd check 'src/**/*.ts.md'",
-    "start": "node dist/tsup/app.js"
+    "start": "node dist/tsup/app.js",
+    "test": "vitest run"
   },
   "dependencies": {
     "@sterashima78/ts-md-unplugin": "workspace:*"
   },
   "devDependencies": {
-    "@sterashima78/ts-md-cli": "workspace:*"
+    "@sterashima78/ts-md-cli": "workspace:*",
+    "@sterashima78/ts-md-core": "workspace:*"
   }
 }

--- a/packages/sandbox/src/app.ts.md
+++ b/packages/sandbox/src/app.ts.md
@@ -8,3 +8,9 @@ console.log(msg)
 ```ts foo
 export const msg = 'hello sandbox'
 ```
+
+```ts greet
+export function greet(name) {
+  return `Hello, ${name}!`
+}
+```

--- a/packages/sandbox/test/app.test.ts
+++ b/packages/sandbox/test/app.test.ts
@@ -1,0 +1,8 @@
+import { greet } from '#../src/app.ts.md:greet';
+import { describe, expect, it } from 'vitest';
+
+describe('app.ts.md', () => {
+  it('greet 関数を実行できる', () => {
+    expect(greet('Vitest')).toBe('Hello, Vitest!');
+  });
+});

--- a/packages/sandbox/vitest.config.ts
+++ b/packages/sandbox/vitest.config.ts
@@ -1,0 +1,9 @@
+import tsMd from '@sterashima78/ts-md-unplugin/vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsMd],
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
       '@sterashima78/ts-md-cli':
         specifier: workspace:*
         version: link:../cli
+      '@sterashima78/ts-md-core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/unplugin:
     dependencies:


### PR DESCRIPTION
## Summary
- add vitest config and placeholder test for `sandbox`
- document how to run tests for the sandbox package
- sandbox テストを ts.md を参照する内容に修正し、`@sterashima78/ts-md-core` を devDependencies に追加
- greet 関数を `app.ts.md` に追加し、ローダー経由で実行するテストに更新
- テストを ts.md の直接 import を使う形に修正

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684b4a0030e08325a93bbacc5e5c89cd