### PR TITLE
Update unplugin to query-based virtual modules

### DIFF
--- a/.changeset/query-blocks.md
+++ b/.changeset/query-blocks.md
@@ -1,0 +1,5 @@
+---
+"@sterashima78/ts-md-unplugin": minor
+---
+unplugin の仮想モジュール形式をクエリベースに変更し、
+ts.md ファイルを各ブロックを再 export する TS として扱うようにしました。

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -27,3 +27,8 @@ import '#./app.ts.md:foo'
 ```ts
 import type { Greeter } from '#./types.ts.md:greeter'
 ```
+
+## モジュール間依存のある ts.md ファイルの例
+
+`src/mini-core` には複数の `.ts.md` ファイルが互いに import し合う簡易例を置いています。
+`src/mini-core/index.ts` 経由で各モジュールを参照できます。

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,1 +1,2 @@
 import '#./app.ts.md:main';
+export * from './mini-core/index.js';

--- a/packages/sandbox/src/mini-core/graph.ts.md
+++ b/packages/sandbox/src/mini-core/graph.ts.md
@@ -1,0 +1,11 @@
+# Graph
+
+```ts graph
+import { parse } from '#./parser.ts.md:parser'
+import { resolveImport } from '#./resolver.ts.md:resolver'
+
+export function detectCycle(entry: string): string {
+  parse(entry)
+  return resolveImport(entry, entry)
+}
+```

--- a/packages/sandbox/src/mini-core/index.ts
+++ b/packages/sandbox/src/mini-core/index.ts
@@ -1,0 +1,4 @@
+export { parse } from '#./parser.ts.md:parser';
+export { resolveImport } from '#./resolver.ts.md:resolver';
+export { detectCycle } from '#./graph.ts.md:graph';
+export { tangle } from '#./tangle.ts.md:tangle';

--- a/packages/sandbox/src/mini-core/parser.ts.md
+++ b/packages/sandbox/src/mini-core/parser.ts.md
@@ -1,0 +1,13 @@
+# Parser
+
+```ts parser
+import { extIsTs } from '#./utils.ts.md:utils'
+
+export interface ChunkDict {
+  [name: string]: string
+}
+
+export function parse(input: string): ChunkDict {
+  return extIsTs(input) ? { main: input } : {}
+}
+```

--- a/packages/sandbox/src/mini-core/resolver.ts.md
+++ b/packages/sandbox/src/mini-core/resolver.ts.md
@@ -1,0 +1,7 @@
+# Resolver
+
+```ts resolver
+export function resolveImport(specifier: string, importer: string): string {
+  return `${importer}/${specifier}`
+}
+```

--- a/packages/sandbox/src/mini-core/tangle.ts.md
+++ b/packages/sandbox/src/mini-core/tangle.ts.md
@@ -1,0 +1,9 @@
+# Tangle
+
+```ts tangle
+import { detectCycle } from '#./graph.ts.md:graph'
+
+export function tangle(entry: string): string {
+  return detectCycle(entry)
+}
+```

--- a/packages/sandbox/src/mini-core/utils.ts.md
+++ b/packages/sandbox/src/mini-core/utils.ts.md
@@ -1,0 +1,5 @@
+# Utils
+
+```ts utils
+export const extIsTs = (file: string): boolean => file.endsWith('.ts');
+```

--- a/packages/sandbox/test/mini-core.test.ts
+++ b/packages/sandbox/test/mini-core.test.ts
@@ -1,0 +1,8 @@
+import { tangle } from '#../src/mini-core/tangle.ts.md:tangle';
+import { describe, expect, it } from 'vitest';
+
+describe('mini-core.ts.md', () => {
+  it('imports across files', () => {
+    expect(tangle('entry')).toBe('entry/entry');
+  });
+});

--- a/packages/unplugin/test/index.test.ts
+++ b/packages/unplugin/test/index.test.ts
@@ -30,11 +30,20 @@ describe('ts-md-unplugin', () => {
     const p = (Array.isArray(plugin) ? plugin[0] : plugin) as Plugin;
     // biome-ignore lint/suspicious/noExplicitAny: plugin context not needed for test
     const resolved = (p as any).resolveId('#./doc.ts.md:main', entry);
-    expect(resolved).toBeTruthy();
+    expect(resolved).toBe(`${mdPath}?block=main&lang.ts`);
     const id = resolved as string;
     // biome-ignore lint/suspicious/noExplicitAny: plugin context not needed for test
     const loaded = await (p as any).load(id);
     const code = typeof loaded === 'string' ? loaded : loaded?.code;
     expect(code?.trim()).toBe("export const msg = 'hi'");
+  });
+
+  it('re-exports blocks from document', async () => {
+    const plugin = unpluginFactory.rollup();
+    const p = (Array.isArray(plugin) ? plugin[0] : plugin) as Plugin;
+    // biome-ignore lint/suspicious/noExplicitAny: plugin context not needed for test
+    const loaded = await (p as any).load(mdPath);
+    const code = typeof loaded === 'string' ? loaded : loaded?.code;
+    expect(code?.trim()).toBe(`export * from '${mdPath}?block=main&lang.ts'`);
   });
 });


### PR DESCRIPTION
## Summary
- adapt unplugin to expose blocks as query based virtual modules
- update tests for new unplugin behaviour
- add sandbox example with multiple ts.md files importing each other

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm -F @sterashima78/ts-md-sandbox build`


------
https://chatgpt.com/codex/tasks/task_e_684c2a8f18248325a1ffb11d352ff556