### PR TITLE
Add emit command to CLI

### DIFF
--- a/.changeset/tall-times-sort.md
+++ b/.changeset/tall-times-sort.md
@@ -1,0 +1,5 @@
+---
+"@sterashima78/ts-md-cli": minor
+---
+
+`emit` コマンドを追加し、`.ts.md` から `.d.ts` を生成できるようにしました。

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,6 +7,7 @@ so that documents can be type-checked, tangled into real files and executed.
 - `check` – run type checking for the specified documents
 - `tangle` – extract chunks to the given directory
 - `run` – execute a document with the Node loader
+- `emit` – generate declaration files for the specified documents
 
 ## Structure
 - `src/commands/` – implementations of each command

--- a/packages/cli/src/commands/emit.ts
+++ b/packages/cli/src/commands/emit.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { parseChunks, resolveImport } from '@sterashima78/ts-md-core';
+import ts from 'typescript';
+import { expandGlobs } from '../utils/globs';
+
+export async function runEmit(inputGlobs: string[], outDir = 'dist') {
+  const files = await expandGlobs(inputGlobs);
+  await fsp.mkdir(outDir, { recursive: true });
+
+  for (const file of files) {
+    const md = await fsp.readFile(file, 'utf8');
+    const dict = parseChunks(md, file);
+
+    for (const [chunk, code] of Object.entries(dict)) {
+      await emitChunk(file, chunk, code, outDir);
+    }
+  }
+}
+
+async function emitChunk(
+  file: string,
+  chunk: string,
+  code: string,
+  outDir: string,
+) {
+  const name = `${file}:${chunk}.ts`;
+  const options: ts.CompilerOptions = {
+    declaration: true,
+    emitDeclarationOnly: true,
+    module: ts.ModuleKind.CommonJS,
+  };
+  const cache: Record<string, Record<string, string>> = {};
+  const host = ts.createCompilerHost(options);
+  function getChunkCode(p: string, c: string) {
+    if (!cache[p]) {
+      const mdText = fs.readFileSync(p, 'utf8');
+      cache[p] = parseChunks(mdText, p);
+    }
+    return cache[p][c];
+  }
+  host.getSourceFile = (f, l) => {
+    if (f === name) return ts.createSourceFile(f, code, l);
+    const m = /(.+\.ts\.md):(.+)\.ts$/.exec(f);
+    if (m) {
+      const chunkCode = getChunkCode(m[1], m[2]);
+      if (chunkCode) return ts.createSourceFile(f, chunkCode, l);
+    }
+    return ts.createSourceFile(f, fs.readFileSync(f, 'utf8'), l);
+  };
+  host.readFile = (f) => {
+    if (f === name) return code;
+    const m = /(.+\.ts\.md):(.+)\.ts$/.exec(f);
+    if (m) {
+      const chunkCode = getChunkCode(m[1], m[2]);
+      if (chunkCode) return chunkCode;
+    }
+    return fs.readFileSync(f, 'utf8');
+  };
+  host.fileExists = (f) => {
+    if (f === name) return true;
+    const m = /(.+\.ts\.md):(.+)\.ts$/.exec(f);
+    if (m) {
+      const chunkCode = getChunkCode(m[1], m[2]);
+      return chunkCode !== undefined;
+    }
+    return fs.existsSync(f);
+  };
+  host.resolveModuleNames = (mods, containing) =>
+    mods.map((n) => {
+      const info = resolveImport(n, file);
+      if (info) {
+        return {
+          resolvedFileName: `${info.absPath}:${info.chunk}.ts`,
+          extension: ts.Extension.Ts,
+        } as ts.ResolvedModule;
+      }
+      const res = ts.resolveModuleName(
+        n,
+        containing,
+        options,
+        host,
+      ).resolvedModule;
+      return res as ts.ResolvedModule;
+    });
+  host.writeFile = (fileName, text) => {
+    const rel = path.join(path.basename(file, '.ts.md'), `${chunk}.d.ts`);
+    const target = path.join(outDir, rel);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, text, 'utf8');
+    console.log(`✨ emitted ${target}`);
+  };
+  const program = ts.createProgram([name], options, host);
+  program.emit();
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import { runCheck } from './commands/check';
+import { runEmit } from './commands/emit';
 import { runTsMd } from './commands/run';
 import { runTangle } from './commands/tangle';
 
@@ -17,6 +18,14 @@ program
   .description('Extract code chunks to real files')
   .action((globs: string[], opts: { outDir: string }) =>
     runTangle(globs, opts.outDir),
+  );
+
+program
+  .command('emit [globs...]')
+  .option('-o, --outDir <dir>', 'output directory', 'dist')
+  .description('Generate declaration files for .ts.md chunks')
+  .action((globs: string[], opts: { outDir: string }) =>
+    runEmit(globs, opts.outDir),
   );
 
 program

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: ['src/index.ts'],
   target: 'node18',
   format: ['esm'],
+  platform: 'node',
   shims: false,
   splitting: false,
   clean: true,
@@ -18,5 +19,6 @@ export default defineConfig({
     '@sterashima78/ts-md-loader',
     'vscode-uri',
     'tsx/esm',
+    'typescript',
   ],
 });


### PR DESCRIPTION
## Summary
- implement `emit` command in CLI to output `.d.ts` files
- expose new command in CLI entry
- document emit command
- adjust tsup config for node platform and exclude TypeScript
- add changeset for minor release

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm -F @sterashima78/ts-md-sandbox exec tsmd emit 'src/**/*.ts.md' -o dist/types`

------
https://chatgpt.com/codex/tasks/task_e_684ca9fc4cc08325acdd3dcd058d783a