### PR TITLE
Add postbuild emit for sandbox

### DIFF
--- a/.changeset/emit-command.md
+++ b/.changeset/emit-command.md
@@ -1,0 +1,6 @@
+---
+"@sterashima78/ts-md-cli": minor
+"@sterashima78/ts-md-ls-core": minor
+---
+
+cli に ts.md から型情報を生成する `emit` コマンドを追加しました。

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,6 +6,7 @@ so that documents can be type-checked, tangled into real files and executed.
 ## Commands
 - `check` – run type checking for the specified documents
 - `tangle` – extract chunks to the given directory
+- `emit` – generate declaration files for the specified documents
 - `run` – execute a document with the Node loader
 
 ## Structure

--- a/packages/cli/src/commands/emit.ts
+++ b/packages/cli/src/commands/emit.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs/promises';
+import { emitDeclarations } from '@sterashima78/ts-md-ls-core';
+import pc from 'picocolors';
+import { expandGlobs } from '../utils/globs';
+
+export async function runEmit(globs: string[], outDir = 'dist') {
+  const files = await expandGlobs(globs);
+  if (!files.length) return console.log(pc.yellow('No .ts.md files found.'));
+  await fs.mkdir(outDir, { recursive: true });
+  const outFiles = await emitDeclarations(files, outDir);
+  for (const f of outFiles) {
+    console.log(`✨ wrote ${f}`);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import { runCheck } from './commands/check';
+import { runEmit } from './commands/emit';
 import { runTsMd } from './commands/run';
 import { runTangle } from './commands/tangle';
 
@@ -17,6 +18,14 @@ program
   .description('Extract code chunks to real files')
   .action((globs: string[], opts: { outDir: string }) =>
     runTangle(globs, opts.outDir),
+  );
+
+program
+  .command('emit [globs...]')
+  .option('-o, --outDir <dir>', 'output directory', 'dist')
+  .description('Emit .d.ts files for .ts.md documents')
+  .action((globs: string[], opts: { outDir: string }) =>
+    runEmit(globs, opts.outDir),
   );
 
 program

--- a/packages/cli/test/emit.test.ts
+++ b/packages/cli/test/emit.test.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { runEmit } from '../src/commands/emit';
+
+describe('emit', () => {
+  it('writes declaration files', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'emit-'));
+    const file = path.join(tmp, 'doc.ts.md');
+    const md = ['```ts foo', 'export const x: number = 1', '```'].join('\n');
+    await fs.writeFile(file, md);
+    const out = path.join(tmp, 'out');
+    await runEmit([file], out);
+    const dts = await fs.readFile(path.join(out, 'doc', 'foo.d.ts'), 'utf8');
+    expect(dts.trim()).toBe('export declare const x: number;');
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+});

--- a/packages/e2e/test/emit.test.ts
+++ b/packages/e2e/test/emit.test.ts
@@ -1,0 +1,20 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const fixture = path.join(__dirname, 'fixtures', 'cross-dep.ts.md');
+const pkgRoot = path.join(__dirname, '..');
+
+describe('emit command e2e', () => {
+  it('writes declaration files via CLI', async () => {
+    const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'emit-e2e-'));
+    execSync(`pnpm exec tsmd emit ${fixture} -o ${outDir}`, { cwd: pkgRoot });
+    const dts = await fs.readFile(
+      path.join(outDir, 'cross-dep', 'foo.d.ts'),
+      'utf8',
+    );
+    expect(dts.trim()).toBe('export declare const val = "cross value";');
+  });
+});

--- a/packages/ls-core/src/index.ts
+++ b/packages/ls-core/src/index.ts
@@ -3,6 +3,7 @@ export type { TsMdVirtualFile } from './virtual-file.js';
 export {
   createTsMdLanguageService,
   collectDiagnostics,
+  emitDeclarations,
   type TsMdDiagnostic,
   type TsMdDiagnosticsResult,
 } from './service.js';

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -8,6 +8,7 @@
     "build:tsup": "tsup",
     "build:vite": "vite build",
     "build": "pnpm build:vite && pnpm build:tsup",
+    "postbuild": "tsx scripts/postbuild.ts",
     "typecheck": "tsmd check 'src/**/*.ts.md'",
     "start": "node dist/tsup/app.js",
     "test": "vitest run"

--- a/packages/sandbox/scripts/postbuild.ts
+++ b/packages/sandbox/scripts/postbuild.ts
@@ -1,0 +1,12 @@
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+
+function main() {
+  const root = join(__dirname, '..');
+  execSync('pnpm exec tsmd emit "src/**/*.ts.md" -o dist/types', {
+    cwd: root,
+    stdio: 'inherit',
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary
- add postbuild script in sandbox package
- generate declaration files via `tsmd emit`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684ca9fc4cc08325acdd3dcd058d783a