### PR TITLE
feat: integrate volar kit checker

### DIFF
--- a/.changeset/195b88f6.md
+++ b/.changeset/195b88f6.md
@@ -1,0 +1,5 @@
+---
+"@sterashima78/ts-md-ls-core": minor
+"@sterashima78/ts-md-cli": patch
+---
+@volar/kit を使った新しいチェック実装を導入しました。CLI の `check` コマンドが ls-core の新しい Checker を利用するようになりました。

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,6 +1,6 @@
 import {
   type TsMdDiagnosticsResult,
-  collectDiagnostics,
+  createTsMdChecker,
 } from '@sterashima78/ts-md-ls-core';
 import pc from 'picocolors';
 import { expandGlobs } from '../utils/globs';
@@ -9,7 +9,15 @@ export async function runCheck(globs: string[]) {
   const files = await expandGlobs(globs);
   if (!files.length) return console.log(pc.yellow('No .ts.md files found.'));
 
-  const result: TsMdDiagnosticsResult = await collectDiagnostics(files);
+  const checker = createTsMdChecker(files);
+  const result: TsMdDiagnosticsResult = {};
+  for (const file of files) {
+    const diags = await checker.check(file);
+    result[file] = diags.map((d) => ({
+      message: d.message,
+      range: d.range,
+    }));
+  }
   let errorCount = 0;
 
   for (const file of files) {

--- a/packages/ls-core/package.json
+++ b/packages/ls-core/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@volar/language-core": "^2.4.14",
     "@volar/language-service": "^2.4.14",
+    "@volar/kit": "^2.4.14",
     "vscode-uri": "^3.0.8",
     "@sterashima78/ts-md-core": "workspace:*"
   },

--- a/packages/ls-core/src/checker.ts
+++ b/packages/ls-core/src/checker.ts
@@ -1,0 +1,30 @@
+import { createTypeScriptInferredChecker } from '@volar/kit';
+import type { LanguagePlugin } from '@volar/language-core';
+import type { Diagnostic } from '@volar/language-service';
+import type { URI } from 'vscode-uri';
+import { tsMdLanguagePlugin } from './plugin.js';
+import type { TsMdDiagnostic, TsMdDiagnosticsResult } from './service.js';
+import type { TsMdVirtualFile } from './virtual-file.js';
+
+export function createTsMdChecker(files: string[]) {
+  const plugin = tsMdLanguagePlugin as unknown as LanguagePlugin<
+    URI,
+    TsMdVirtualFile
+  >;
+  return createTypeScriptInferredChecker([plugin], [], () => files);
+}
+
+export async function collectDiagnosticsWithKit(
+  files: string[],
+): Promise<TsMdDiagnosticsResult> {
+  const checker = createTsMdChecker(files);
+  const result: TsMdDiagnosticsResult = {};
+  for (const file of files) {
+    const diags = (await checker.check(file)) as Diagnostic[];
+    result[file] = diags.map((d) => ({
+      message: d.message,
+      range: d.range,
+    }));
+  }
+  return result;
+}

--- a/packages/ls-core/src/index.ts
+++ b/packages/ls-core/src/index.ts
@@ -6,3 +6,7 @@ export {
   type TsMdDiagnostic,
   type TsMdDiagnosticsResult,
 } from './service.js';
+export {
+  createTsMdChecker,
+  collectDiagnosticsWithKit,
+} from './checker.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@sterashima78/ts-md-core':
         specifier: workspace:*
         version: link:../core
+      '@volar/kit':
+        specifier: ^2.4.14
+        version: 2.4.14(typescript@5.8.3)
       '@volar/language-core':
         specifier: ^2.4.14
         version: 2.4.14
@@ -952,6 +955,11 @@ packages:
 
   '@vitest/utils@3.2.1':
     resolution: {integrity: sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==}
+
+  '@volar/kit@2.4.14':
+    resolution: {integrity: sha512-kBcmHjEodtmYGJELHePZd2JdeYm4ZGOd9F/pQ1YETYIzAwy4Z491EkJ1nRSo/GTxwKt0XYwYA/dHSEgXecVHRA==}
+    peerDependencies:
+      typescript: '*'
 
   '@volar/language-core@2.4.14':
     resolution: {integrity: sha512-X6beusV0DvuVseaOEy7GoagS4rYHgDHnTrdOj5jeUb49fW5ceQyP9Ej5rBhqgz2wJggl+2fDbbojq1XKaxDi6w==}
@@ -2675,6 +2683,9 @@ packages:
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
 
+  typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -3679,6 +3690,15 @@ snapshots:
       '@vitest/pretty-format': 3.2.1
       loupe: 3.1.3
       tinyrainbow: 2.0.0
+
+  '@volar/kit@2.4.14(typescript@5.8.3)':
+    dependencies:
+      '@volar/language-service': 2.4.14
+      '@volar/typescript': 2.4.14
+      typesafe-path: 0.2.2
+      typescript: 5.8.3
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
 
   '@volar/language-core@2.4.14':
     dependencies:
@@ -5595,6 +5615,8 @@ snapshots:
       qs: 6.14.0
       tunnel: 0.0.6
       underscore: 1.13.7
+
+  typesafe-path@0.2.2: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
## Summary
- implement `createTsMdChecker` via `@volar/kit`
- expose new checker utilities from ls-core
- update CLI `check` command to use new checker
- add dependency on `@volar/kit`
- include a changeset

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684d274ee8c88325bd33aae50f990704