### PR TITLE
Use volar kit for CLI checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.7.0",
+    "@changesets/changelog-github": "^0.5.1",
+    "@changesets/cli": "^2.29.4",
     "@types/node": "^22.15.29",
+    "@volar/kit": "^2.4.14",
     "tsup": "^8.5.0",
     "turbo": "^2.5.4",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
-    "vitest": "^3.2.1",
-    "@changesets/cli": "^2.29.4",
-    "@changesets/changelog-github": "^0.5.1"
+    "vitest": "^3.2.1"
   },
   "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
     "commander": "^11",
     "fast-glob": "^3.3.3",
     "picocolors": "^1.0.0",
+    "@volar/kit": "^2.4.14",
     "tsx": "^4"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,23 +1,28 @@
 import {
-  type TsMdDiagnosticsResult,
-  collectDiagnostics,
+  type TsMdVirtualFile,
+  createTsMdPlugin,
 } from '@sterashima78/ts-md-ls-core';
+import { createTypeScriptInferredChecker } from '@volar/kit';
+import type { Diagnostic, LanguagePlugin } from '@volar/language-service';
 import pc from 'picocolors';
+import type { URI } from 'vscode-uri';
 import { expandGlobs } from '../utils/globs';
 
 export async function runCheck(globs: string[]) {
   const files = await expandGlobs(globs);
   if (!files.length) return console.log(pc.yellow('No .ts.md files found.'));
 
-  const result: TsMdDiagnosticsResult = await collectDiagnostics(files);
-  let errorCount = 0;
+  const checker = createTypeScriptInferredChecker(
+    [createTsMdPlugin as unknown as LanguagePlugin<URI, TsMdVirtualFile>],
+    [],
+    () => files,
+  );
 
+  let errorCount = 0;
   for (const file of files) {
-    const diags = result[file] ?? [];
-    for (const d of diags) {
-      console.error(
-        `${pc.red('error')} ${file}:${d.range.start.line + 1}:${d.range.start.character + 1} ${d.message}`,
-      );
+    const diags = (await checker.check(file)) as Diagnostic[];
+    if (diags.length) {
+      console.error(checker.printErrors(file, diags));
     }
     errorCount += diags.length;
   }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     'fast-glob',
     'picocolors',
     '@volar/language-service',
+    '@volar/kit',
     '@sterashima78/ts-md-ls-core',
     '@sterashima78/ts-md-core',
     '@sterashima78/ts-md-loader',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/node':
         specifier: ^22.15.29
         version: 22.15.29
+      '@volar/kit':
+        specifier: ^2.4.14
+        version: 2.4.14(typescript@5.8.3)
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(postcss@8.5.4)(tsx@4.19.4)(typescript@5.8.3)
@@ -47,6 +50,9 @@ importers:
       '@sterashima78/ts-md-ls-core':
         specifier: workspace:*
         version: link:../ls-core
+      '@volar/kit':
+        specifier: ^2.4.14
+        version: 2.4.14(typescript@5.8.3)
       commander:
         specifier: ^11
         version: 11.1.0
@@ -952,6 +958,11 @@ packages:
 
   '@vitest/utils@3.2.1':
     resolution: {integrity: sha512-KkHlGhePEKZSub5ViknBcN5KEF+u7dSUr9NW8QsVICusUojrgrOnnY3DEWWO877ax2Pyopuk2qHmt+gkNKnBVw==}
+
+  '@volar/kit@2.4.14':
+    resolution: {integrity: sha512-kBcmHjEodtmYGJELHePZd2JdeYm4ZGOd9F/pQ1YETYIzAwy4Z491EkJ1nRSo/GTxwKt0XYwYA/dHSEgXecVHRA==}
+    peerDependencies:
+      typescript: '*'
 
   '@volar/language-core@2.4.14':
     resolution: {integrity: sha512-X6beusV0DvuVseaOEy7GoagS4rYHgDHnTrdOj5jeUb49fW5ceQyP9Ej5rBhqgz2wJggl+2fDbbojq1XKaxDi6w==}
@@ -2675,6 +2686,9 @@ packages:
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
 
+  typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -3679,6 +3693,15 @@ snapshots:
       '@vitest/pretty-format': 3.2.1
       loupe: 3.1.3
       tinyrainbow: 2.0.0
+
+  '@volar/kit@2.4.14(typescript@5.8.3)':
+    dependencies:
+      '@volar/language-service': 2.4.14
+      '@volar/typescript': 2.4.14
+      typesafe-path: 0.2.2
+      typescript: 5.8.3
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
 
   '@volar/language-core@2.4.14':
     dependencies:
@@ -5595,6 +5618,8 @@ snapshots:
       qs: 6.14.0
       tunnel: 0.0.6
       underscore: 1.13.7
+
+  typesafe-path@0.2.2: {}
 
   typescript@5.8.3: {}
 


### PR DESCRIPTION
## Summary
- add `@volar/kit`
- integrate volar kit into CLI `check`
- keep tsup external list up to date

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm -F @sterashima78/ts-md-sandbox typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684d274ee8c88325bd33aae50f990704