### PR TITLE
Add tsmd options for sandbox

### DIFF
--- a/.changeset/some-shrimps-draw.md
+++ b/.changeset/some-shrimps-draw.md
@@ -1,0 +1,5 @@
+---
+"@sterashima78/ts-md-cli": minor
+"@sterashima78/ts-md-sandbox": patch
+---
+CLI で check コマンドに TypeScript オプションを渡せるようにしました。sandbox の typecheck では --noEmit を、postbuild では --emitDeclarationOnly を使用します。また、tsconfig に `.ts.md` を含め、ファイルグロブを渡さずにチェックするようにしました。

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -9,16 +9,20 @@ import pc from 'picocolors';
 import { expandGlobs } from '../utils/globs';
 
 export async function runCheck(globs: string[]) {
-  const files = await expandGlobs(globs);
+  const files = await expandGlobs(globs.filter((g) => !g.startsWith('-')));
   if (!files.length) return console.log(pc.yellow('No .ts.md files found.'));
 
   const require = createRequire(import.meta.url);
 
   // tsc \u306b\u6b21\u306e\u30d5\u30a1\u30a4\u30eb\u3092\u6e21\u3059
   const idx = process.argv.indexOf('check');
+  const rest =
+    idx >= 0
+      ? process.argv.slice(idx + 1).filter((a) => a.startsWith('-'))
+      : [];
   process.argv =
     idx >= 0
-      ? [...process.argv.slice(0, idx), ...files]
+      ? [...process.argv.slice(0, idx), ...files, ...rest]
       : [process.argv[0], process.argv[1], ...files];
 
   runTsc(require.resolve('typescript/lib/tsc'), ['.ts.md'], () => ({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,8 +8,9 @@ const program = new Command('tsmd');
 
 program
   .command('check [globs...]')
+  .allowUnknownOption()
   .description('Type-check .ts.md files')
-  .action((globs: string[]) => runCheck(globs));
+  .action((globs: string[], _opts: unknown, cmd: Command) => runCheck(globs));
 
 program
   .command('tangle [globs...]')

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -8,7 +8,8 @@
     "build:tsup": "tsup",
     "build:vite": "vite build",
     "build": "pnpm build:vite && pnpm build:tsup",
-    "typecheck": "tsmd check 'src/**/*.ts.md'",
+    "typecheck": "tsmd check --noEmit",
+    "postbuild": "tsmd check --emitDeclarationOnly --outDir dist/types",
     "start": "node dist/tsup/app.js",
     "test": "vitest run"
   },

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "src/**/*.ts.md"]
 }


### PR DESCRIPTION
## Summary
- allow `tsmd check` to pass TypeScript options
- use `--noEmit` for sandbox typecheck
- run declaration generation on postbuild
- include `.ts.md` files via tsconfig instead of globs

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684d5f742ce483258c0eabb77edc55cd