### PR TITLE
vscode パッケージスクリプト修正

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -9,7 +9,7 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup && tsx scripts/postbuild.ts",
-    "package": "vsce package",
+    "package": "tsx scripts/package.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "download": "tsx scripts/download.ts"

--- a/packages/vscode/scripts/package.ts
+++ b/packages/vscode/scripts/package.ts
@@ -1,0 +1,40 @@
+import { spawn } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function run(command: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else
+        reject(
+          new Error(`${command} ${args.join(' ')} exited with code ${code}`),
+        );
+    });
+  });
+}
+
+async function main() {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const pkgPath = join(__dirname, '../package.json');
+  const text = await readFile(pkgPath, 'utf8');
+  const pkg = JSON.parse(text) as { name: string };
+  const originalName = pkg.name;
+  pkg.name = 'ts-md';
+  await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+  try {
+    await run('pnpm', ['exec', 'vsce', 'package'], join(__dirname, '..'));
+  } finally {
+    pkg.name = originalName;
+    await writeFile(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- vscode パッケージの `package` タスクを TypeScript スクリプト化
- 一時的に `package.json` の `name` を変更しパッケージングを実行

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684d6f4c26f483259bf4762a20eead7d