### PR TITLE
update ls-core uri handling

### DIFF
--- a/.changeset/ls-core-uri-filepath.md
+++ b/.changeset/ls-core-uri-filepath.md
@@ -1,0 +1,4 @@
+---
+"@sterashima78/ts-md-ls-core": minor
+---
+`TsMdVirtualFile` に `filePath` プロパティを追加し、URI と ID の生成方法を変更しました。

--- a/packages/ls-core/src/plugin.ts
+++ b/packages/ls-core/src/plugin.ts
@@ -26,9 +26,9 @@ export const tsMdLanguagePlugin = {
     const dict = getChunkDict(snapshot, filePath);
     const uri =
       typeof fileName === 'string'
-        ? pathToFileURL(fileName).href
+        ? fileName
         : (fileName as unknown as { toString(): string }).toString();
-    return new TsMdVirtualFile(snapshot, uri, dict);
+    return new TsMdVirtualFile(snapshot, uri, filePath, dict);
   },
 
   updateVirtualCode(

--- a/packages/ls-core/src/virtual-file.ts
+++ b/packages/ls-core/src/virtual-file.ts
@@ -10,6 +10,7 @@ export class TsMdVirtualFile implements VirtualCode {
   constructor(
     public snapshot: ts.IScriptSnapshot,
     public uri: string,
+    public filePath: string,
     private dict: Record<string, string>,
   ) {
     this.refreshEmbedded();
@@ -24,7 +25,7 @@ export class TsMdVirtualFile implements VirtualCode {
 
   private refreshEmbedded() {
     this.embeddedCodes = Object.entries(this.dict).map(([name, code]) => ({
-      id: `#${this.uri}:${name}`,
+      id: `${this.filePath}__${name}.ts`,
       languageId: 'ts',
       mappings: [],
       snapshot: {


### PR DESCRIPTION
## Summary
- tweak TsMd language plugin to store filepath instead of file URL when creating virtual files
- add `filePath` property to `TsMdVirtualFile` and update embedded id generation
- add changeset for `ls-core`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684e989b3c9c83259b52220ab6bbef5e