### PR TITLE
Update vscode packaging script comment

### DIFF
--- a/packages/vscode/scripts/package.ts
+++ b/packages/vscode/scripts/package.ts
@@ -1,3 +1,7 @@
+// VS Code 拡張パッケージ処理でパッケージ名に
+// スラッシュを含むと失敗するため、
+// name を一時的に "ts-md" に更えてパッケージ完了後に
+// 元に戻す。
 import { spawn } from 'node:child_process';
 import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';


### PR DESCRIPTION
## Summary
- document workaround for vsce failing on scoped package names

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684e26e059c483259361fb2a30116810