### PR TITLE
Fix id handling in ls-core virtual file

### DIFF
--- a/.changeset/cli-simplify-check.md
+++ b/.changeset/cli-simplify-check.md
@@ -1,0 +1,4 @@
+---
+"@sterashima78/ts-md-cli": patch
+---
+check コマンドを tsc にそのまま引数を渡す方式に変更しました

--- a/.changeset/drop-hash-specifiers.md
+++ b/.changeset/drop-hash-specifiers.md
@@ -1,0 +1,8 @@
+---
+"@sterashima78/ts-md-core": minor
+"@sterashima78/ts-md-loader": minor
+"@sterashima78/ts-md-unplugin": minor
+"@sterashima78/ts-md-ls-core": minor
+"@sterashima78/ts-md-cli": minor
+---
+import specifier from "#file:chunk" 形式を廃止し、`./file.ts.md:chunk` を利用するようにしました。

--- a/.changeset/ls-core-id-fix.md
+++ b/.changeset/ls-core-id-fix.md
@@ -1,0 +1,4 @@
+---
+"@sterashima78/ts-md-ls-core": patch
+---
+TsMdVirtualFile の id をファイルパスに変更し、プラグインで正しく認識されるようにしました。

--- a/.changeset/ls-core-md-extension.md
+++ b/.changeset/ls-core-md-extension.md
@@ -1,0 +1,4 @@
+---
+"@sterashima78/ts-md-ls-core": patch
+---
+runTsc の拡張子指定を .md とし、プラグインで *.ts.md だけを処理するようにしました

--- a/.changeset/shorthand-imports.md
+++ b/.changeset/shorthand-imports.md
@@ -1,0 +1,6 @@
+---
+"@sterashima78/ts-md-core": minor
+"@sterashima78/ts-md-ls-core": minor
+"@sterashima78/ts-md-unplugin": minor
+---
+同一ファイル内のチャンクは `:name` のようにファイル名を省略して参照できるようにしました。

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@ CLI toolset for working with `.ts.md` files. It wraps the core parser and loader
 so that documents can be type-checked, tangled into real files and executed.
 
 ## Commands
-- `check` – run type checking for the specified documents
+- `check` – tsc と同様に `.ts.md` を型チェックします
 - `tangle` – extract chunks to the given directory
 - `run` – execute a document with the Node loader
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,10 +7,10 @@ import { runTangle } from './commands/tangle';
 const program = new Command('tsmd');
 
 program
-  .command('check [globs...]')
+  .command('check [args...]')
   .allowUnknownOption()
-  .description('Type-check .ts.md files')
-  .action((globs: string[], _opts: unknown, cmd: Command) => runCheck(globs));
+  .description('tsc と同様に .ts.md を型チェックします')
+  .action(() => runCheck());
 
 program
   .command('tangle [globs...]')

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@ imports and tangles code blocks into real files.
 
 ## Modules
 - `parser.ts` – extract named code chunks from Markdown
-- `resolver.ts` – resolve `#file:chunk` style imports
+ - `resolver.ts` – resolve `file.ts.md:chunk` and `:chunk` imports
 - `graph.ts` – detect import cycles between chunks
 - `tangle.ts` – write chunks to disk
 - `utils.ts` – helper functions

--- a/packages/core/src/graph.ts
+++ b/packages/core/src/graph.ts
@@ -18,7 +18,8 @@ export function detectCycle(
     const dict = dictProvider(file);
     const code = dict?.[chunk];
     if (code) {
-      const importRegex = /import\s+(?:.+?\s+from\s+)?['"](#.+?)['"]/g;
+      const importRegex =
+        /import\s+(?:.+?\s+from\s+)?['"]([^'"\n]*(?:\.ts\.md)?:[^'"\n]+)['"]/g;
       let m: RegExpExecArray | null = null;
       while (true) {
         m = importRegex.exec(code);

--- a/packages/core/src/resolver.ts
+++ b/packages/core/src/resolver.ts
@@ -4,17 +4,17 @@ export function resolveImport(
   specifier: string,
   importer: string,
 ): { absPath: string; chunk: string } | undefined {
-  if (!specifier.startsWith('#')) return undefined;
-  const body = specifier.slice(1);
-  if (!body) return undefined;
-  const cleanImporter = importer.replace(/^\0?ts-md:/, '').replace(/\?.*$/, '');
-  if (body.includes(':')) {
-    const idx = body.indexOf(':');
-    const rel = body.slice(0, idx);
-    const chunk = body.slice(idx + 1);
-    if (!rel || !chunk) return undefined;
-    const absPath = path.resolve(path.dirname(cleanImporter), rel);
-    return { absPath, chunk };
+  if (!(specifier.includes('.ts.md:') || specifier.startsWith(':'))) {
+    return undefined;
   }
-  return { absPath: cleanImporter, chunk: body };
+  const idx = specifier.lastIndexOf(':');
+  if (idx === -1) return undefined;
+  const rel = specifier.slice(0, idx);
+  const chunk = specifier.slice(idx + 1);
+  if (!chunk) return undefined;
+  const cleanImporter = importer.replace(/^\0?ts-md:/, '').replace(/\?.*$/, '');
+  const absPath = rel
+    ? path.resolve(path.dirname(cleanImporter), rel)
+    : cleanImporter;
+  return { absPath, chunk };
 }

--- a/packages/core/test/graph.test.ts
+++ b/packages/core/test/graph.test.ts
@@ -5,7 +5,7 @@ import { resolveImport } from '../src/resolver';
 describe('detectCycle', () => {
   it('detects no cycle', () => {
     const dicts = new Map<string, Record<string, string>>();
-    dicts.set('/a.ts.md', { main: "import '#./b.ts.md:dep'" });
+    dicts.set('/a.ts.md', { main: "import './b.ts.md:dep'" });
     dicts.set('/b.ts.md', { dep: 'export const x = 1' });
     const res = detectCycle('/a.ts.md:main', (f) => dicts.get(f));
     expect(res).toBeNull();
@@ -13,7 +13,7 @@ describe('detectCycle', () => {
 
   it('detects self cycle', () => {
     const dicts = new Map<string, Record<string, string>>();
-    dicts.set('/a.ts.md', { main: "import '#./a.ts.md:main'" });
+    dicts.set('/a.ts.md', { main: "import './a.ts.md:main'" });
     const res = detectCycle('/a.ts.md:main', (f) => dicts.get(f));
     expect(res).toEqual(['/a.ts.md:main', '/a.ts.md:main']);
   });

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -6,7 +6,7 @@ import { parseChunks } from '../src/parser';
 import { resolveImport } from '../src/resolver';
 import { tangle } from '../src/tangle';
 
-const md = ['```ts main', "import '#./dep.ts.md:dep'", '```'].join('\n');
+const md = ['```ts main', "import './dep.ts.md:dep'", '```'].join('\n');
 
 const depMd = ['```ts dep', 'export const msg = 1', '```'].join('\n');
 
@@ -17,7 +17,7 @@ describe('integration', () => {
     const depDict = parseChunks(depMd, path.join(tmp, 'dep.ts.md'));
     const all = { ...dict, ...depDict };
     await tangle(all, path.join(tmp, 'doc.ts.md'), tmp);
-    const r = resolveImport('#./dep.ts.md:dep', path.join(tmp, 'doc.ts.md'));
+    const r = resolveImport('./dep.ts.md:dep', path.join(tmp, 'doc.ts.md'));
     const file = r?.absPath;
     const content = await fs.readFile(
       path.join(tmp, 'doc.ts', 'dep.ts'),

--- a/packages/core/test/resolver.test.ts
+++ b/packages/core/test/resolver.test.ts
@@ -3,15 +3,19 @@ import { resolveImport } from '../src/resolver';
 
 describe('resolveImport', () => {
   it('resolves relative path', () => {
-    const res = resolveImport('#./foo.ts.md:bar', '/a/b/main.ts.md');
+    const res = resolveImport('./foo.ts.md:bar', '/a/b/main.ts.md');
     expect(res).toEqual({ absPath: '/a/b/foo.ts.md', chunk: 'bar' });
   });
   it('resolves parent dir', () => {
-    const res = resolveImport('#../foo.ts.md:baz', '/a/b/c/app.ts.md');
+    const res = resolveImport('../foo.ts.md:baz', '/a/b/c/app.ts.md');
     expect(res).toEqual({ absPath: '/a/b/foo.ts.md', chunk: 'baz' });
   });
   it('resolves chunk in same file', () => {
-    const res = resolveImport('#qux', '/a/b/doc.ts.md');
+    const res = resolveImport('./doc.ts.md:qux', '/a/b/doc.ts.md');
+    expect(res).toEqual({ absPath: '/a/b/doc.ts.md', chunk: 'qux' });
+  });
+  it('resolves shorthand same-file import', () => {
+    const res = resolveImport(':qux', '/a/b/doc.ts.md');
     expect(res).toEqual({ absPath: '/a/b/doc.ts.md', chunk: 'qux' });
   });
 });

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "allowArbitraryExtensions": true
   },
-  "include": ["src", "src/**/*.ts.md"]
+  "include": ["src/**/*.ts", "src/**/*.md"]
 }

--- a/packages/e2e/src/fixtures/error-project/bad.ts.md
+++ b/packages/e2e/src/fixtures/error-project/bad.ts.md
@@ -5,6 +5,6 @@ export const add = (a: number, b: number) => a + b
 ```
 
 ```ts main
-import { add } from '#./bad.ts.md:foo'
+import { add } from ':foo'
 add('1', 2)
 ```

--- a/packages/e2e/test/fixtures/cross-error-main.ts.md
+++ b/packages/e2e/test/fixtures/cross-error-main.ts.md
@@ -1,7 +1,7 @@
 # Cross Error Main
 
 ```ts main
-import { num } from '#./cross-error-dep.ts.md:foo'
+import { num } from './cross-error-dep.ts.md:foo'
 const str: string = num
 console.log(str)
 ```

--- a/packages/e2e/test/fixtures/cross-main.ts.md
+++ b/packages/e2e/test/fixtures/cross-main.ts.md
@@ -1,7 +1,7 @@
 # Cross Main
 
 ```ts main
-import { val } from '#./cross-dep.ts.md:foo'
+import { val } from './cross-dep.ts.md:foo'
 const str: string = val
 console.log(str)
 ```

--- a/packages/e2e/test/fixtures/multi-error.ts.md
+++ b/packages/e2e/test/fixtures/multi-error.ts.md
@@ -5,7 +5,7 @@ export const num: number = 123
 ```
 
 ```ts main
-import { num } from '#foo'
+import { num } from ':foo'
 const str: string = num
 console.log(str)
 ```

--- a/packages/e2e/test/fixtures/multi.ts.md
+++ b/packages/e2e/test/fixtures/multi.ts.md
@@ -5,6 +5,6 @@ export const msg = 'multi success'
 ```
 
 ```ts main
-import { msg } from '#foo'
+import { msg } from ':foo'
 console.log(msg)
 ```

--- a/packages/e2e/test/loader.test.ts
+++ b/packages/e2e/test/loader.test.ts
@@ -22,7 +22,7 @@ describe('loader e2e', () => {
         '```',
         '',
         '```ts main',
-        'import { msg } from "#foo"',
+        'import { msg } from ":foo"',
         'console.log(msg)',
         '```',
       ].join('\n'),

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -32,7 +32,7 @@ export const resolve: Resolve = async (specifier, context, defaultResolve) => {
   const specPath = specifier.startsWith('file:')
     ? fileURLToPath(specifier)
     : specifier;
-  if (specifier.startsWith('#') && parentURL) {
+  if (parentURL) {
     const info = resolveImport(specifier, parentURL);
     if (info) {
       const abs = path.resolve(info.absPath);

--- a/packages/loader/test/index.test.ts
+++ b/packages/loader/test/index.test.ts
@@ -21,7 +21,7 @@ describe('ts-md-loader', () => {
         '```',
         '',
         '```ts main',
-        'import { msg } from "#foo"',
+        'import { msg } from ":foo"',
         'console.log(msg)',
         '```',
       ].join('\n'),

--- a/packages/ls-core/src/service.ts
+++ b/packages/ls-core/src/service.ts
@@ -34,7 +34,7 @@ export function createTsMdLanguageService(files: string[]) {
     if (scripts.has(id)) return;
     let filePath: string;
     if (typeof id === 'string') {
-      const m = /^#(.+):/.exec(id);
+      const m = /^(.+):/.exec(id);
       if (!m) return;
       filePath = URI.parse(m[1]).fsPath;
     } else {

--- a/packages/ls-core/src/virtual-file.ts
+++ b/packages/ls-core/src/virtual-file.ts
@@ -2,7 +2,7 @@ import type { VirtualCode } from '@volar/language-core';
 import type ts from 'typescript';
 
 export class TsMdVirtualFile implements VirtualCode {
-  id = 'root';
+  id!: string;
   languageId = 'ts';
   mappings: [] = [];
   embeddedCodes: VirtualCode[] = [];
@@ -12,6 +12,7 @@ export class TsMdVirtualFile implements VirtualCode {
     public uri: string,
     private dict: Record<string, string>,
   ) {
+    this.id = uri;
     this.refreshEmbedded();
   }
 
@@ -24,7 +25,7 @@ export class TsMdVirtualFile implements VirtualCode {
 
   private refreshEmbedded() {
     this.embeddedCodes = Object.entries(this.dict).map(([name, code]) => ({
-      id: `#${this.uri}:${name}`,
+      id: `${this.uri}:${name}`,
       languageId: 'ts',
       mappings: [],
       snapshot: {

--- a/packages/ls-core/test/index.test.ts
+++ b/packages/ls-core/test/index.test.ts
@@ -32,8 +32,8 @@ describe('ts-md-ls-core diagnostics', () => {
         '# Main',
         '',
         '```ts main',
-        "import '#./a.ts.md:foo'",
-        "import { msg } from '#./a.ts.md:foo'",
+        "import './a.ts.md:foo'",
+        "import { msg } from './a.ts.md:foo'",
         'console.log(msg)',
         '```',
       ].join('\n'),
@@ -58,7 +58,7 @@ describe('ts-md-ls-core diagnostics', () => {
       if (scripts.has(id)) return;
       let filePath: string;
       if (typeof id === 'string') {
-        const m = /^#(.+):/.exec(id);
+        const m = /^(.+):/.exec(id);
         if (!m) return;
         filePath = URI.parse(m[1]).fsPath;
       } else {

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -16,7 +16,7 @@ pnpm -F @sterashima78/ts-md-sandbox test
 `src/import-example.ts` では `.ts` ファイルから `.ts.md` ファイルのチャンクをインポートしています。
 
 ```ts
-import '#./app.ts.md:foo'
+import './app.ts.md:foo'
 ```
 
 ## ts.md ファイルから type インポートする例
@@ -25,7 +25,7 @@ import '#./app.ts.md:foo'
 インポートしています。
 
 ```ts
-import type { Greeter } from '#./types.ts.md:greeter'
+import type { Greeter } from './types.ts.md:greeter'
 ```
 
 ## モジュール間依存のある ts.md ファイルの例

--- a/packages/sandbox/src/app.ts.md
+++ b/packages/sandbox/src/app.ts.md
@@ -1,7 +1,7 @@
 # Sandbox
 
 ```ts main
-import { msg } from '#foo'
+import { msg } from ':foo'
 console.log(msg)
 ```
 

--- a/packages/sandbox/src/import-example.ts
+++ b/packages/sandbox/src/import-example.ts
@@ -1,1 +1,1 @@
-import '#./app.ts.md:foo';
+import './app.ts.md:foo';

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,2 +1,2 @@
-import '#./app.ts.md:main';
+import './app.ts.md:main';
 export * from './mini-core/index.js';

--- a/packages/sandbox/src/mini-core/graph.ts.md
+++ b/packages/sandbox/src/mini-core/graph.ts.md
@@ -1,8 +1,8 @@
 # Graph
 
 ```ts graph
-import { parse } from '#./parser.ts.md:parser'
-import { resolveImport } from '#./resolver.ts.md:resolver'
+import { parse } from './parser.ts.md:parser'
+import { resolveImport } from './resolver.ts.md:resolver'
 
 export function detectCycle(entry: string): string {
   parse(entry)

--- a/packages/sandbox/src/mini-core/index.ts
+++ b/packages/sandbox/src/mini-core/index.ts
@@ -1,4 +1,4 @@
-export { parse } from '#./parser.ts.md:parser';
-export { resolveImport } from '#./resolver.ts.md:resolver';
-export { detectCycle } from '#./graph.ts.md:graph';
-export { tangle } from '#./tangle.ts.md:tangle';
+export { parse } from './parser.ts.md:parser';
+export { resolveImport } from './resolver.ts.md:resolver';
+export { detectCycle } from './graph.ts.md:graph';
+export { tangle } from './tangle.ts.md:tangle';

--- a/packages/sandbox/src/mini-core/parser.ts.md
+++ b/packages/sandbox/src/mini-core/parser.ts.md
@@ -1,7 +1,7 @@
 # Parser
 
 ```ts parser
-import { extIsTs } from '#./utils.ts.md:utils'
+import { extIsTs } from './utils.ts.md:utils'
 
 export interface ChunkDict {
   [name: string]: string

--- a/packages/sandbox/src/mini-core/tangle.ts.md
+++ b/packages/sandbox/src/mini-core/tangle.ts.md
@@ -1,7 +1,7 @@
 # Tangle
 
 ```ts tangle
-import { detectCycle } from '#./graph.ts.md:graph'
+import { detectCycle } from './graph.ts.md:graph'
 
 export function tangle(entry: string): string {
   return detectCycle(entry)

--- a/packages/sandbox/src/type-import-example.ts
+++ b/packages/sandbox/src/type-import-example.ts
@@ -1,4 +1,4 @@
-import type { Greeter } from '#./types.ts.md:greeter';
+import type { Greeter } from './types.ts.md:greeter';
 
 const greeter: Greeter = {
   greet(message) {

--- a/packages/sandbox/test/app.test.ts
+++ b/packages/sandbox/test/app.test.ts
@@ -1,5 +1,5 @@
-import { greet } from '#../src/app.ts.md:greet';
 import { describe, expect, it } from 'vitest';
+import { greet } from '../src/app.ts.md:greet';
 
 describe('app.ts.md', () => {
   it('greet 関数を実行できる', () => {

--- a/packages/sandbox/test/mini-core.test.ts
+++ b/packages/sandbox/test/mini-core.test.ts
@@ -1,5 +1,5 @@
-import { tangle } from '#../src/mini-core/tangle.ts.md:tangle';
 import { describe, expect, it } from 'vitest';
+import { tangle } from '../src/mini-core/tangle.ts.md:tangle';
 
 describe('mini-core.ts.md', () => {
   it('imports across files', () => {

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "allowArbitraryExtensions": true
   },
-  "include": ["src", "src/**/*.ts.md"]
+  "include": ["src/**/*.ts", "src/**/*.md"]
 }

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -16,7 +16,7 @@ export const unplugin = createUnplugin((options: Options | undefined) => {
     name: 'ts-md',
     enforce: 'pre',
     resolveId(id, importer) {
-      if (!id.startsWith('#') || !importer) return;
+      if (!(id.includes('.ts.md:') || id.startsWith(':')) || !importer) return;
       const info = resolveImport(id, importer);
       if (!info) return;
       const absPath = info.absPath;

--- a/packages/unplugin/test/index.test.ts
+++ b/packages/unplugin/test/index.test.ts
@@ -16,7 +16,7 @@ describe('ts-md-unplugin', () => {
       mdPath,
       ['# Doc', '', '```ts main', "export const msg = 'hi'", '```'].join('\n'),
     );
-    fs.writeFileSync(entry, "import '#./doc.ts.md:main';");
+    fs.writeFileSync(entry, "import './doc.ts.md:main';");
 
     unpluginFactory = (await import('../src')).unplugin;
   });
@@ -29,7 +29,7 @@ describe('ts-md-unplugin', () => {
     const plugin = unpluginFactory.rollup();
     const p = (Array.isArray(plugin) ? plugin[0] : plugin) as Plugin;
     // biome-ignore lint/suspicious/noExplicitAny: plugin context not needed for test
-    const resolved = (p as any).resolveId('#./doc.ts.md:main', entry);
+    const resolved = (p as any).resolveId('./doc.ts.md:main', entry);
     expect(resolved).toBe(`${mdPath}?block=main&lang.ts`);
     const id = resolved as string;
     // biome-ignore lint/suspicious/noExplicitAny: plugin context not needed for test


### PR DESCRIPTION
## Summary
- maintain file path as `TsMdVirtualFile.id`
- add a changeset for `ls-core`
- avoid mis-resolving imports without `.ts.md:`
- allow `runCheck()` to handle no-arg case
- permit `:chunk` shorthand for imports within the same file

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684e61bbec948325b545cfe6d971c844