### PR TITLE
Fix VS Code types version mismatch

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -22,7 +22,7 @@
     "tsx": "^4.8.1"
   },
   "devDependencies": {
-    "@types/vscode": "^1.89.0",
+    "@types/vscode": "^1.85.0",
     "@vscode/test-electron": "^2.4.2",
     "typescript": "^5.5.0",
     "vitest": "^1.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,7 +228,7 @@ importers:
         version: 3.1.0
     devDependencies:
       '@types/vscode':
-        specifier: ^1.89.0
+        specifier: ^1.85.0
         version: 1.100.0
       '@vscode/test-electron':
         specifier: ^2.4.2


### PR DESCRIPTION
## Summary
- adjust `packages/vscode` to use `@types/vscode@^1.85.0`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm exec tsx scripts/package.ts` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ec4b764448325a386e6a939e83b6d