### PR TITLE
feat(tsc): add ts-md-tsc package

### DIFF
--- a/.changeset/add-ts-md-tsc.md
+++ b/.changeset/add-ts-md-tsc.md
@@ -1,0 +1,4 @@
+---
+"@sterashima78/ts-md-tsc": minor
+---
+新しく ts-md-tsc パッケージを追加し、`.ts.md` を型検査して型定義を生成できるようにしました。

--- a/packages/tsc/README.md
+++ b/packages/tsc/README.md
@@ -1,0 +1,8 @@
+# @sterashima78/ts-md-tsc
+
+`vue-tsc` のように `.ts.md` ファイルを型検査し、型定義を生成するツールです。
+TypeScript の `tsc` と同じ引数を受け付けます。
+
+```
+$ ts-md-tsc -p tsconfig.json
+```

--- a/packages/tsc/index.js
+++ b/packages/tsc/index.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import './dist/index.js';

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@sterashima78/ts-md-tsc",
+  "version": "0.0.0",
+  "type": "module",
+  "bin": {
+    "ts-md-tsc": "./index.js"
+  },
+  "main": "dist/index.js",
+  "files": ["dist", "index.js"],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@volar/typescript": "^2.4.14",
+    "@sterashima78/ts-md-ls-core": "workspace:*"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
+}

--- a/packages/tsc/src/index.ts
+++ b/packages/tsc/src/index.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { createRequire } from 'node:module';
+import { createTsMdPlugin } from '@sterashima78/ts-md-ls-core';
+import { runTsc } from '@volar/typescript/lib/quickstart/runTsc';
+
+const require = createRequire(import.meta.url);
+
+runTsc(
+  require.resolve('typescript/lib/tsc'),
+  {
+    extraSupportedExtensions: ['.md'],
+    extraExtensionsToRemove: ['.md'],
+  },
+  () => ({
+    languagePlugins: [createTsMdPlugin],
+  }),
+);

--- a/packages/tsc/test/placeholder.test.ts
+++ b/packages/tsc/test/placeholder.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('placeholder', () => {
+  it('works', () => {
+    expect(1).toBe(1);
+  });
+});

--- a/packages/tsc/tsconfig.json
+++ b/packages/tsc/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/tsc/tsup.config.ts
+++ b/packages/tsc/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node18',
+  dts: false,
+  clean: true,
+  splitting: false,
+  external: ['@volar/typescript', '@sterashima78/ts-md-ls-core', 'typescript'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,15 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/tsc:
+    dependencies:
+      '@sterashima78/ts-md-ls-core':
+        specifier: workspace:*
+        version: link:../ls-core
+      '@volar/typescript':
+        specifier: ^2.4.14
+        version: 2.4.14
+
   packages/unplugin:
     dependencies:
       '@rollup/pluginutils':
@@ -3578,7 +3587,7 @@ snapshots:
     dependencies:
       '@sterashima78/ts-md-core': 0.0.4(typescript@5.8.3)
       '@sterashima78/ts-md-loader': 0.0.4
-      '@sterashima78/ts-md-ls-core': 0.0.4(typescript@5.8.3)
+      '@sterashima78/ts-md-ls-core': 0.0.4
       '@volar/kit': 2.4.14(typescript@5.8.3)
       '@volar/typescript': 2.4.14
       commander: 11.1.0
@@ -3637,7 +3646,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@sterashima78/ts-md-ls-core@0.0.4(typescript@5.8.3)':
+  '@sterashima78/ts-md-ls-core@0.0.4':
     dependencies:
       '@sterashima78/ts-md-core': 0.0.4(typescript@5.8.3)
       '@volar/language-core': 2.4.14
@@ -3645,7 +3654,6 @@ snapshots:
       vscode-uri: 3.1.0
     transitivePeerDependencies:
       - supports-color
-      - typescript
 
   '@sterashima78/ts-md-ls-core@0.1.0(typescript@5.8.3)':
     dependencies:


### PR DESCRIPTION
## Summary
- 新しい `@sterashima78/ts-md-tsc` パッケージを追加し、`.ts.md` の型検査と型定義生成を行う `runTsc` ベースの CLI を実装
- リリース用 changeset を追加

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68500af4cacc8325a1fc908f93d418db