### PR TITLE
Use ts-md-tsc for sandbox typecheck

### DIFF
--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -1,6 +1,7 @@
 # @sterashima78/ts-md-sandbox
 
 unplugin の検証用サンドボックス。`.ts.md` ファイルを tsup または Vite でビルドして実行します。
+型チェックと型定義生成には `ts-md-tsc` を使用しています。
 
 ```
 pnpm -F @sterashima78/ts-md-sandbox build

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -8,8 +8,8 @@
     "build:tsup": "tsup",
     "build:vite": "vite build",
     "build": "pnpm build:vite && pnpm build:tsup",
-    "typecheck": "tsmd check --noEmit",
-    "postbuild": "tsmd check --emitDeclarationOnly --outDir dist/types",
+    "typecheck": "ts-md-tsc -p tsconfig.json --noEmit",
+    "postbuild": "ts-md-tsc -p tsconfig.json --emitDeclarationOnly --outDir dist/types",
     "start": "node dist/tsup/app.js",
     "test": "vitest run"
   },
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@sterashima78/ts-md-cli": "workspace:*",
-    "@sterashima78/ts-md-core": "workspace:*"
+    "@sterashima78/ts-md-core": "workspace:*",
+    "@sterashima78/ts-md-tsc": "workspace:*"
   }
 }

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
     "allowArbitraryExtensions": true
   },
   "include": ["src/**/*.ts", "src/**/*.md"]

--- a/packages/tsc/src/index.ts
+++ b/packages/tsc/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { createRequire } from 'node:module';
 import { createTsMdPlugin } from '@sterashima78/ts-md-ls-core';
-import { runTsc } from '@volar/typescript/lib/quickstart/runTsc';
+import { runTsc } from '@volar/typescript/lib/quickstart/runTsc.js';
 
 const require = createRequire(import.meta.url);
 

--- a/packages/tsc/test/placeholder.test.ts
+++ b/packages/tsc/test/placeholder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 describe('placeholder', () => {
   it('works', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       '@sterashima78/ts-md-core':
         specifier: workspace:*
         version: link:../core
+      '@sterashima78/ts-md-tsc':
+        specifier: workspace:*
+        version: link:../tsc
 
   packages/tsc:
     dependencies:


### PR DESCRIPTION
## Summary
- use `ts-md-tsc` in sandbox scripts
- document `ts-md-tsc`
- allow emitting from sandbox tsconfig
- fix ts-md-tsc path to `runTsc.js`
- fix import order in placeholder test

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: cannot find modules from `.ts.md` imports)*
- `pnpm -F @sterashima78/ts-md-sandbox build` *(fails: Vite cannot load generated chunk)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68500f0dbe308325b6ce3b09bbbe9c91