### PR TITLE
Remove ts sources in sandbox

### DIFF
--- a/packages/sandbox/src/app.ts
+++ b/packages/sandbox/src/app.ts
@@ -1,4 +1,0 @@
-export const msg = 'hello sandbox';
-export function greet(name: string) {
-  return `Hello, ${name}!`;
-}

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,2 +1,2 @@
-import './app.js';
+import './app.ts.md';
 export * from './mini-core/index.js';

--- a/packages/sandbox/src/mini-core/graph.ts
+++ b/packages/sandbox/src/mini-core/graph.ts
@@ -1,7 +1,0 @@
-import { parse } from './parser.js';
-import { resolveImport } from './resolver.js';
-
-export function detectCycle(entry: string): string {
-  parse(entry);
-  return resolveImport(entry, entry);
-}

--- a/packages/sandbox/src/mini-core/index.ts
+++ b/packages/sandbox/src/mini-core/index.ts
@@ -1,4 +1,4 @@
-export { parse } from './parser.js';
-export { resolveImport } from './resolver.js';
-export { detectCycle } from './graph.js';
-export { tangle } from './tangle.js';
+export { parse } from './parser.ts.md';
+export { resolveImport } from './resolver.ts.md';
+export { detectCycle } from './graph.ts.md';
+export { tangle } from './tangle.ts.md';

--- a/packages/sandbox/src/mini-core/parser.ts
+++ b/packages/sandbox/src/mini-core/parser.ts
@@ -1,9 +1,0 @@
-import { extIsTs } from './utils.js';
-
-export interface ChunkDict {
-  [name: string]: string;
-}
-
-export function parse(input: string): ChunkDict {
-  return extIsTs(input) ? { main: input } : {};
-}

--- a/packages/sandbox/src/mini-core/resolver.ts
+++ b/packages/sandbox/src/mini-core/resolver.ts
@@ -1,3 +1,0 @@
-export function resolveImport(specifier: string, importer: string): string {
-  return `${importer}/${specifier}`;
-}

--- a/packages/sandbox/src/mini-core/tangle.ts
+++ b/packages/sandbox/src/mini-core/tangle.ts
@@ -1,5 +1,0 @@
-import { detectCycle } from './graph.js';
-
-export function tangle(entry: string): string {
-  return detectCycle(entry);
-}

--- a/packages/sandbox/src/mini-core/utils.ts
+++ b/packages/sandbox/src/mini-core/utils.ts
@@ -1,1 +1,0 @@
-export const extIsTs = (file: string): boolean => file.endsWith('.ts');

--- a/packages/sandbox/src/type-import-example.ts
+++ b/packages/sandbox/src/type-import-example.ts
@@ -1,4 +1,4 @@
-import type { Greeter } from './types.js';
+import type { Greeter } from './types.ts.md';
 
 const greeter: Greeter = {
   greet(message: string) {

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -1,3 +1,0 @@
-export interface Greeter {
-  greet(message: string): void;
-}


### PR DESCRIPTION
## Summary
- delete sandbox `.ts` sources duplicated from `.ts.md`
- adjust imports to use `.ts.md` versions

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: File is not a module)*
- `pnpm test`
- `pnpm build` *(fails: File is not a module)*

------
https://chatgpt.com/codex/tasks/task_e_68515135a0248325b57a9c76ce620670