### PR TITLE
Move chunk info parser to core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@sterashima78/ts-md-unplugin": "0.2.0",
-    "@sterashima78/ts-md-cli": "^0.3.0"
+    "@sterashima78/ts-md-cli": "^0.3.0",
+    "@types/mdast": "^4.0.4"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
-export { parseChunks } from './parser';
+export { parseChunks, parseChunkInfos } from './parser';
+export type { ChunkInfo } from './parser';
 export { resolveImport } from './resolver';
 export { detectCycle } from './graph';
 export { tangle } from './tangle';

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -1,3 +1,4 @@
+import type { Code, Html, Root } from 'mdast';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
@@ -33,5 +34,52 @@ export function parseChunks(markdown: string, uri: string): ChunkDict {
     }
   });
 
+  return dict;
+}
+
+export interface ChunkInfo {
+  code: string;
+  start: number;
+  end: number;
+}
+
+export function parseChunkInfos(
+  markdown: string,
+  uri: string,
+): Record<string, ChunkInfo> {
+  const tree = unified().use(remarkParse).parse(markdown) as Root;
+  const dict: Record<string, ChunkInfo> = {};
+  let pendingFile: string | null = null;
+  visit(tree, (node) => {
+    if (node.type === 'html') {
+      const value = (node as Html).value ?? '';
+      const m = /<!--\s*file:\s*([^>]+)-->/.exec(value);
+      if (m) {
+        pendingFile = m[1].trim();
+      }
+    }
+
+    if (node.type === 'code' && extIsTs((node as Code).lang ?? '')) {
+      const meta = (node as Code).meta ?? '';
+      const name = meta.trim();
+      if (!name) return;
+      const key = pendingFile ?? name;
+      const pos = node.position;
+      const start = pos?.start.offset ?? 0;
+      const end = pos?.end.offset ?? start + (node as Code).value.length;
+      const full = markdown.slice(start, end);
+      const idx = full.indexOf((node as Code).value);
+      const codeStart = idx === -1 ? start : start + idx;
+      const code = (node as Code).value;
+      if (dict[key]) {
+        const prev = dict[key];
+        prev.code += `\n${code}`;
+        prev.end = codeStart + code.length;
+      } else {
+        dict[key] = { code, start: codeStart, end: codeStart + code.length };
+      }
+      pendingFile = null;
+    }
+  });
   return dict;
 }

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseChunks } from '../src/parser';
+import { parseChunkInfos, parseChunks } from '../src/parser';
 
 const md = [
   '# Title',
@@ -23,5 +23,14 @@ describe('parseChunks', () => {
   it('extracts named chunks', () => {
     expect(Object.keys(dict)).toEqual(['foo', 'path/to/bar.ts']);
     expect(dict.foo.trim().split('\n').length).toBe(2);
+  });
+});
+
+describe('parseChunkInfos', () => {
+  const dict = parseChunkInfos(md, '/doc.ts.md');
+  it('includes start and end offsets', () => {
+    expect(dict.foo.start).toBeLessThan(dict.foo.end);
+    expect(dict.foo.code).toContain('console.log(3)');
+    expect(dict['path/to/bar.ts'].code).toContain('console.log(2)');
   });
 });

--- a/packages/ls-core/src/parsers.ts
+++ b/packages/ls-core/src/parsers.ts
@@ -1,4 +1,4 @@
-import { parseChunks } from '@sterashima78/ts-md-core';
+import { parseChunkInfos, parseChunks } from '@sterashima78/ts-md-core';
 import type ts from 'typescript';
 
 /** キャッシュ付きで Markdown をチャンク辞書へ */
@@ -10,4 +10,11 @@ export function getChunkDict(snapshot: ts.IScriptSnapshot, uri: string) {
     dict[name] = chunk;
   }
   return dict;
+}
+
+export type { ChunkInfo } from '@sterashima78/ts-md-core';
+
+export function getChunkInfoDict(snapshot: ts.IScriptSnapshot, uri: string) {
+  const text = snapshot.getText(0, snapshot.getLength());
+  return parseChunkInfos(text, uri);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@sterashima78/ts-md-unplugin':
         specifier: 0.2.0
         version: 0.2.0(typescript@5.8.3)
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
 
   packages/e2e:
     dependencies:


### PR DESCRIPTION
## Summary
- add `parseChunkInfos` and `ChunkInfo` to core
- use `parseChunkInfos` from ls-core
- update dependencies
- add tests for position parsing

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6851510c09208325a663873a247902b8