### PR TITLE
Fix ts.md plugin to use markdown root and ts embeds

### DIFF
--- a/packages/ls-core/package.json
+++ b/packages/ls-core/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@volar/language-core": "^2.4.14",
     "@volar/language-service": "^2.4.14",
+    "@volar/typescript": "^2.4.14",
     "vscode-uri": "^3.0.8",
     "@sterashima78/ts-md-core": "workspace:*"
   },

--- a/packages/ls-core/src/virtual-file.ts
+++ b/packages/ls-core/src/virtual-file.ts
@@ -1,11 +1,11 @@
-import type { Mapping, VirtualCode } from '@volar/language-core';
+import type { CodeMapping, Mapping, VirtualCode } from '@volar/language-core';
 import type ts from 'typescript';
 import { getChunkInfoDict } from './parsers.js';
 
 export class TsMdVirtualFile implements VirtualCode {
   id!: string;
-  languageId = 'ts';
-  mappings: [] = [];
+  languageId = 'markdown';
+  mappings: CodeMapping[] = [];
   embeddedCodes: VirtualCode[] = [];
   linkedCodeMappings: Mapping[] = [];
 
@@ -30,6 +30,21 @@ export class TsMdVirtualFile implements VirtualCode {
     this.embeddedCodes = [];
     this.linkedCodeMappings = [];
     this.dict = {};
+    this.mappings = [
+      {
+        sourceOffsets: [0],
+        generatedOffsets: [0],
+        lengths: [this.snapshot.getLength()],
+        data: {
+          completion: true,
+          format: true,
+          navigation: true,
+          semantic: true,
+          structure: true,
+          verification: true,
+        },
+      },
+    ];
 
     for (const [name, info] of Object.entries(infoDict)) {
       const { code, start } = info;

--- a/packages/sandbox/tsconfig.json
+++ b/packages/sandbox/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "allowArbitraryExtensions": true,
-    "baseUrl": ".",
-    "paths": {
-      "*.ts.md": ["*.ts.md__main.ts"]
-    }
+    "baseUrl": "."
   },
   "include": ["src/**/*.ts", "src/**/*.ts.md"]
 }

--- a/packages/tsc/src/index.ts
+++ b/packages/tsc/src/index.ts
@@ -8,8 +8,8 @@ const require = createRequire(import.meta.url);
 runTsc(
   require.resolve('typescript/lib/tsc'),
   {
-    extraSupportedExtensions: ['.md'],
-    extraExtensionsToRemove: ['.md'],
+    extraSupportedExtensions: ['.ts.md'],
+    extraExtensionsToRemove: ['.ts.md'],
   },
   () => ({
     languagePlugins: [createTsMdPlugin],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@volar/language-service':
         specifier: ^2.4.14
         version: 2.4.14
+      '@volar/typescript':
+        specifier: ^2.4.14
+        version: 2.4.14
       vscode-uri:
         specifier: ^3.0.8
         version: 3.1.0


### PR DESCRIPTION
## Summary
- treat `.ts.md` files as markdown containers with embedded TypeScript
- add mappings to `TsMdVirtualFile`
- generate extra TypeScript service scripts for each code block
- adjust sandbox config and ts-md-tsc extension handling
- include `@volar/typescript` dependency

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6852af4bed8883259db38aadc62a9b44