### PR TITLE
Fix bundle exports

### DIFF
--- a/.changeset/remove-nonmain-exports.md
+++ b/.changeset/remove-nonmain-exports.md
@@ -1,0 +1,4 @@
+---
+"@sterashima78/ts-md-core": patch
+---
+バンドル出力から main 以外のチャンクの export を削除しました。

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -25,8 +25,9 @@ export function bundleMarkdown(
     prefixDeclarations(file, prefix);
   }
 
-  for (const file of Object.values(files)) {
+  for (const [name, file] of Object.entries(files)) {
     transformImportsExports(file);
+    if (name !== entry) removeExports(file);
   }
 
   let output = '';
@@ -168,5 +169,14 @@ function transformImportsExports(file: import('ts-morph').SourceFile) {
       }
       exp.replaceWithText(`export { ${parts.join(', ')} };`);
     }
+  }
+}
+
+function removeExports(file: import('ts-morph').SourceFile) {
+  for (const exp of file.getExportDeclarations()) {
+    exp.remove();
+  }
+  for (const ass of file.getExportAssignments()) {
+    ass.remove();
   }
 }

--- a/packages/core/test/bundle.test.ts
+++ b/packages/core/test/bundle.test.ts
@@ -19,5 +19,6 @@ describe('bundleMarkdown', () => {
   it('bundles chunks with prefix', () => {
     expect(code).toContain('const foo_msg');
     expect(code).toContain('console.log(foo_msg)');
+    expect(code).not.toContain('export { foo_msg as msg }');
   });
 });


### PR DESCRIPTION
## Summary
- drop chunk exports from bundles in ts-md-core
- test that export statements are removed
- add changeset for patch release

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685478ee9f0c83259d32aeebcd324e62