### PR TITLE
Add renaming logic for ts.md declaration files

### DIFF
--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -15,7 +15,9 @@
   },
   "dependencies": {
     "@volar/typescript": "^2.4.14",
-    "@sterashima78/ts-md-ls-core": "workspace:*"
+    "@sterashima78/ts-md-ls-core": "workspace:*",
+    "fast-glob": "^3.3.3",
+    "load-tsconfig": "^0.2.5"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/tsc/src/index.ts
+++ b/packages/tsc/src/index.ts
@@ -1,9 +1,26 @@
 #!/usr/bin/env node
+import fs from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import path from 'node:path';
 import { createTsMdPlugin } from '@sterashima78/ts-md-ls-core';
 import { runTsc } from '@volar/typescript/lib/quickstart/runTsc.js';
+import fg from 'fast-glob';
+import { loadTsConfig } from 'load-tsconfig';
 
 const require = createRequire(import.meta.url);
+
+const args = process.argv.slice(2);
+const project = getOption(args, 'p', 'project') ?? 'tsconfig.json';
+const outDirArg = getOption(args, '', 'outDir');
+const rootDirArg = getOption(args, '', 'rootDir');
+
+const originalExit = process.exit;
+process.exit = ((code = 0) => {
+  renameDeclarations().then(
+    () => originalExit(code),
+    () => originalExit(code),
+  );
+}) as typeof process.exit;
 
 runTsc(
   require.resolve('typescript/lib/tsc'),
@@ -15,3 +32,43 @@ runTsc(
     languagePlugins: [createTsMdPlugin],
   }),
 );
+
+function getOption(args: string[], short: string, long?: string) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (short && arg === `-${short}`) return args[i + 1];
+    if (long && arg === `--${long}`) return args[i + 1];
+    const reg = new RegExp(`^(?:-${short}|--${long})(?:=|$)`);
+    const m = long ? arg.match(reg) : undefined;
+    if (m) return arg.slice(m[0].length);
+  }
+  return undefined;
+}
+
+async function renameDeclarations() {
+  const configPath = path.resolve(project);
+  const config = loadTsConfig(
+    path.dirname(configPath),
+    path.basename(configPath),
+  );
+  const compilerOptions = config?.data.compilerOptions ?? {};
+  const rootDir = path.resolve(
+    path.dirname(configPath),
+    rootDirArg ?? (compilerOptions.rootDir as string | undefined) ?? '.',
+  );
+  const outDir = path.resolve(
+    path.dirname(configPath),
+    outDirArg ?? (compilerOptions.outDir as string | undefined) ?? 'dist',
+  );
+  const files = await fg('**/*.ts.md', { cwd: rootDir });
+  await Promise.all(
+    files.map(async (rel) => {
+      const base = rel.slice(0, -'.ts.md'.length);
+      const from = path.join(outDir, `${base}.d.ts`);
+      const to = path.join(outDir, `${base}.ts.md.d.ts`);
+      try {
+        await fs.rename(from, to);
+      } catch {}
+    }),
+  );
+}

--- a/packages/tsc/src/types/load-tsconfig.d.ts
+++ b/packages/tsc/src/types/load-tsconfig.d.ts
@@ -1,0 +1,11 @@
+declare module 'load-tsconfig' {
+  export interface TsConfig {
+    path: string;
+    data: {
+      compilerOptions?: Record<string, unknown>;
+      [key: string]: unknown;
+    };
+    files: string[];
+  }
+  export function loadTsConfig(dir: string, name?: string): TsConfig | null;
+}

--- a/packages/tsc/tsconfig.json
+++ b/packages/tsc/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": ["src", "src/types"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,12 @@ importers:
       '@volar/typescript':
         specifier: ^2.4.14
         version: 2.4.14
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
+      load-tsconfig:
+        specifier: ^0.2.5
+        version: 0.2.5
 
   packages/unplugin:
     dependencies:


### PR DESCRIPTION
## Summary
- rename declaration outputs for `.ts.md` sources to `.ts.md.d.ts`
- add dependencies `fast-glob` and `load-tsconfig`
- include custom types for `load-tsconfig`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685485a835cc8325b6286b4d905be409