### PR TITLE
Add renaming logic for ts-md declarations

### DIFF
--- a/.changeset/rename-dts-after-tsc.md
+++ b/.changeset/rename-dts-after-tsc.md
@@ -1,0 +1,4 @@
+---
+'@sterashima78/ts-md-tsc': patch
+---
+runTsc 実行後に生成された `.d.ts` ファイルを `.ts.md.d.ts` へリネームするようになりました。


### PR DESCRIPTION
## Summary
- rename `.d.ts` emitted from `.ts.md` sources to `.ts.md.d.ts`
- add a changeset for the new behaviour

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685485a835cc8325b6286b4d905be409