### PR TITLE
core utils.ts を ts.md 化

### DIFF
--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -1,6 +1,6 @@
 import { Project, SyntaxKind } from 'ts-morph';
 import { parseChunkInfos } from './parser.js';
-import { escapeChunk } from './utils.js';
+import { escapeChunk } from './utils.ts.md';
 
 export function bundleMarkdown(
   markdown: string,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,5 +3,5 @@ export type { ChunkInfo } from './parser';
 export { resolveImport } from './resolver';
 export { detectCycle } from './graph';
 export { tangle } from './tangle';
-export * from './utils';
+export * from './utils.ts.md';
 export { bundleMarkdown } from './bundle.js';

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -2,7 +2,7 @@ import type { Code, Html, Root } from 'mdast';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
-import { extIsTs } from './utils';
+import { extIsTs } from './utils.ts.md';
 
 export interface ChunkDict {
   [name: string]: string;

--- a/packages/core/src/tangle.ts
+++ b/packages/core/src/tangle.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { ChunkDict } from './parser';
-import { escapeChunk } from './utils';
+import { escapeChunk } from './utils.ts.md';
 
 export async function tangle(
   dict: ChunkDict,

--- a/packages/core/src/utils.ts.md
+++ b/packages/core/src/utils.ts.md
@@ -1,3 +1,6 @@
+# Utils
+
+```ts main
 import crypto from 'node:crypto';
 
 export function hash(str: string): string {
@@ -11,3 +14,5 @@ export function extIsTs(lang: string): boolean {
 export function escapeChunk(name: string): string {
   return name.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
+```
+

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
     "allowArbitraryExtensions": true
   },
-  "include": ["src/**/*.ts", "src/**/*.md"]
+  "include": ["src/**/*.ts", "src/**/*.ts.md"]
 }

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  dts: true,
+  dts: false,
   format: ['esm'],
   clean: true,
   target: 'node18',

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,9 @@
+import tsMd from '@sterashima78/ts-md-unplugin/vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsMd],
+  test: {
+    globals: true,
+  },
+});

--- a/packages/ls-core/tsconfig.json
+++ b/packages/ls-core/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
-    "module": "nodenext",
-    "moduleResolution": "nodenext"
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowArbitraryExtensions": true
   }
 }


### PR DESCRIPTION
## Summary
- `packages/core` の `utils.ts` を Markdown 形式の `utils.ts.md` に変更
- `packages/core` の TypeScript 設定を更新し `ts.md` ファイルを含める
- tsup の型生成を無効化
- core 用の `vitest.config.ts` を追加
- `packages/ls-core` の TypeScript 設定を調整
- 既存実装のインポートを `utils.ts.md` に変更

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855d535ebd883258b18ce6bdaf49573