### PR TITLE
Convert tangle.ts to Markdown source

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,6 @@ export { parseChunks, parseChunkInfos } from './parser';
 export type { ChunkInfo } from './parser';
 export { resolveImport } from './resolver';
 export { detectCycle } from './graph';
-export { tangle } from './tangle';
+export { tangle } from './tangle.ts.md';
 export * from './utils.ts.md';
 export { bundleMarkdown } from './bundle.js';

--- a/packages/core/src/tangle.ts.md
+++ b/packages/core/src/tangle.ts.md
@@ -1,3 +1,6 @@
+# Tangle
+
+```ts main
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { ChunkDict } from './parser';
@@ -24,3 +27,4 @@ export async function tangle(
 
   return written;
 }
+```

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parseChunks } from '../src/parser';
 import { resolveImport } from '../src/resolver';
-import { tangle } from '../src/tangle';
+import { tangle } from '../src/tangle.ts.md';
 
 const md = ['```ts main', "import './dep.ts.md'", '```'].join('\n');
 

--- a/packages/core/test/tangle.test.ts
+++ b/packages/core/test/tangle.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { tangle } from '../src/tangle';
+import { tangle } from '../src/tangle.ts.md';
 
 describe('tangle', () => {
   it('writes files', async () => {


### PR DESCRIPTION
## Summary
- use Markdown source for the `tangle` implementation in `core`
- update imports
- adjust tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855f4854adc83258dc2b84082b311ef