### PR TITLE
loader パッケージの ts.md 対応

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "@sterashima78/ts-md-core": "workspace:*"
   },
+  "devDependencies": {
+    "@sterashima78/ts-md-unplugin": "0.3.0"
+  },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",
     "access": "public"

--- a/packages/loader/tsconfig.json
+++ b/packages/loader/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "compilerOptions": {
+    "allowArbitraryExtensions": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.ts.md"]
 }

--- a/packages/loader/tsup.config.ts
+++ b/packages/loader/tsup.config.ts
@@ -1,3 +1,4 @@
+import tsMd from '@sterashima78/ts-md-unplugin/esbuild';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
@@ -8,4 +9,5 @@ export default defineConfig({
   target: 'node18',
   outExtension: () => ({ js: '.js' }),
   bundle: false,
+  esbuildPlugins: [tsMd],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,10 @@ importers:
       '@sterashima78/ts-md-core':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@sterashima78/ts-md-unplugin':
+        specifier: 0.3.0
+        version: 0.3.0
 
   packages/ls-core:
     dependencies:


### PR DESCRIPTION
## Summary
- loader パッケージでも `.ts.md` を扱えるよう、設定を更新
- これに伴い `@sterashima78/ts-md-unplugin` を devDependencies に追加

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6855f51e6e7483258d45b6659af47aad