### PR TITLE
Convert core graph to ts.md

### DIFF
--- a/packages/core/src/graph.ts.md
+++ b/packages/core/src/graph.ts.md
@@ -1,3 +1,6 @@
+# Graph
+
+```ts main
 import type { ChunkDict } from './parser';
 import { resolveImport } from './resolver';
 
@@ -42,3 +45,4 @@ function split(node: string): [string, string] {
   const idx = node.lastIndexOf(':');
   return [node.slice(0, idx), node.slice(idx + 1)];
 }
+```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
 export { parseChunks, parseChunkInfos } from './parser';
 export type { ChunkInfo } from './parser';
 export { resolveImport } from './resolver';
-export { detectCycle } from './graph';
+export { detectCycle } from './graph.ts.md';
 export { tangle } from './tangle.ts.md';
 export * from './utils.ts.md';
 export { bundleMarkdown } from './bundle.js';

--- a/packages/core/test/graph.test.ts
+++ b/packages/core/test/graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { detectCycle } from '../src/graph';
+import { detectCycle } from '../src/graph.ts.md';
 import { resolveImport } from '../src/resolver';
 
 describe('detectCycle', () => {


### PR DESCRIPTION
## Summary
- `graph.ts` を `graph.ts.md` に変換
- `index.ts` とテストを更新

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685611e89ec48325ae3953309484002e