### PR TITLE
Convert loader implementation to ts.md

### DIFF
--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -6,14 +6,16 @@
   "files": ["dist"],
   "scripts": {
     "build": "tsup",
-    "typecheck": "tsc --noEmit",
+    "postbuild": "ts-md-tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
+    "typecheck": "ts-md-tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
     "@sterashima78/ts-md-core": "workspace:*"
   },
   "devDependencies": {
-    "@sterashima78/ts-md-unplugin": "0.3.0"
+    "@sterashima78/ts-md-unplugin": "0.3.0",
+    "@sterashima78/ts-md-tsc": "^0.1.0"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/loader/src/index.ts.md
+++ b/packages/loader/src/index.ts.md
@@ -1,16 +1,19 @@
+# Loader
+
+```ts main
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseChunks, resolveImport } from '@sterashima78/ts-md-core';
 import ts from 'typescript';
 
-type Resolve = (
+export type Resolve = (
   specifier: string,
   context: { parentURL?: string | undefined },
   defaultResolve: Resolve,
 ) => Promise<{ url: string }>;
 
-type Load = (
+export type Load = (
   url: string,
   context: { format?: string | undefined },
   defaultLoad: Load,
@@ -111,3 +114,4 @@ export const load: Load = async (url, context, defaultLoad) => {
 
   return defaultLoad(url, context, defaultLoad);
 };
+```

--- a/packages/loader/tsup.config.ts
+++ b/packages/loader/tsup.config.ts
@@ -2,9 +2,9 @@ import tsMd from '@sterashima78/ts-md-unplugin/esbuild';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: { index: 'src/index.ts.md' },
   format: ['esm'],
-  dts: true,
+  dts: false,
   clean: true,
   target: 'node18',
   outExtension: () => ({ js: '.js' }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
         specifier: workspace:*
         version: link:../core
     devDependencies:
+      '@sterashima78/ts-md-tsc':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@sterashima78/ts-md-unplugin':
         specifier: 0.3.0
         version: 0.3.0


### PR DESCRIPTION
## Summary
- loader パッケージの実装ファイルを ts.md 化
- tsup 設定を ts.md 対応に変更
- typecheck と型出力に ts-md-tsc を利用

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685611f797a08325b14e47f7cd1d498b