### PR TITLE
Convert resolver.ts to ts.md

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,7 +5,7 @@ imports and tangles code blocks into real files.
 
 ## Modules
 - `parser.ts` – extract named code chunks from Markdown
- - `resolver.ts` – resolve `file.ts.md:chunk` and `:chunk` imports
+- `resolver.ts.md` – resolve `file.ts.md:chunk` and `:chunk` imports
 - `graph.ts` – detect import cycles between chunks
 - `tangle.ts` – write chunks to disk
 - `utils.ts` – helper functions

--- a/packages/core/src/graph.ts.md
+++ b/packages/core/src/graph.ts.md
@@ -2,7 +2,7 @@
 
 ```ts main
 import type { ChunkDict } from './parser';
-import { resolveImport } from './resolver';
+import { resolveImport } from './resolver.ts.md';
 
 export function detectCycle(
   entry: string,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 export { parseChunks, parseChunkInfos } from './parser';
 export type { ChunkInfo } from './parser';
-export { resolveImport } from './resolver';
+export { resolveImport } from './resolver.ts.md';
 export { detectCycle } from './graph.ts.md';
 export { tangle } from './tangle.ts.md';
 export * from './utils.ts.md';

--- a/packages/core/src/resolver.ts.md
+++ b/packages/core/src/resolver.ts.md
@@ -1,3 +1,6 @@
+# Resolver
+
+```ts main
 import path from 'node:path';
 
 export function resolveImport(
@@ -30,3 +33,4 @@ export function resolveImport(
   }
   return { absPath, chunk };
 }
+```

--- a/packages/core/test/graph.test.ts
+++ b/packages/core/test/graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { detectCycle } from '../src/graph.ts.md';
-import { resolveImport } from '../src/resolver';
+import { resolveImport } from '../src/resolver.ts.md';
 
 describe('detectCycle', () => {
   it('detects no cycle', () => {

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parseChunks } from '../src/parser';
-import { resolveImport } from '../src/resolver';
+import { resolveImport } from '../src/resolver.ts.md';
 import { tangle } from '../src/tangle.ts.md';
 
 const md = ['```ts main', "import './dep.ts.md'", '```'].join('\n');

--- a/packages/core/test/resolver.test.ts
+++ b/packages/core/test/resolver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveImport } from '../src/resolver';
+import { resolveImport } from '../src/resolver.ts.md';
 
 describe('resolveImport', () => {
   it('resolves relative path', () => {


### PR DESCRIPTION
## Summary
- move `resolver.ts` to markdown source format
- update imports in core package to new `.ts.md` file
- update README and tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_685618bae6848325ac344688029b16d9