### PR TITLE
Convert parser to ts.md

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,10 +4,10 @@ Core utilities for `.ts.md` documents. It parses Markdown, resolves chunk
 imports and tangles code blocks into real files.
 
 ## Modules
-- `parser.ts` – extract named code chunks from Markdown
+- `parser.ts.md` – extract named code chunks from Markdown
 - `resolver.ts.md` – resolve `file.ts.md:chunk` and `:chunk` imports
-- `graph.ts` – detect import cycles between chunks
-- `tangle.ts` – write chunks to disk
-- `utils.ts` – helper functions
+- `graph.ts.md` – detect import cycles between chunks
+- `tangle.ts.md` – write chunks to disk
+- `utils.ts.md` – helper functions
 
 Tests live under `test/`.

--- a/packages/core/src/bundle.ts
+++ b/packages/core/src/bundle.ts
@@ -1,5 +1,5 @@
 import { Project, SyntaxKind } from 'ts-morph';
-import { parseChunkInfos } from './parser.js';
+import { parseChunkInfos } from './parser.ts.md';
 import { escapeChunk } from './utils.ts.md';
 
 export function bundleMarkdown(

--- a/packages/core/src/graph.ts.md
+++ b/packages/core/src/graph.ts.md
@@ -1,7 +1,7 @@
 # Graph
 
 ```ts main
-import type { ChunkDict } from './parser';
+import type { ChunkDict } from './parser.ts.md';
 import { resolveImport } from './resolver.ts.md';
 
 export function detectCycle(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
-export { parseChunks, parseChunkInfos } from './parser';
-export type { ChunkInfo } from './parser';
+export { parseChunks, parseChunkInfos } from './parser.ts.md';
+export type { ChunkInfo } from './parser.ts.md';
 export { resolveImport } from './resolver.ts.md';
 export { detectCycle } from './graph.ts.md';
 export { tangle } from './tangle.ts.md';

--- a/packages/core/src/parser.ts.md
+++ b/packages/core/src/parser.ts.md
@@ -1,3 +1,6 @@
+# Parser
+
+```ts main
 import type { Code, Html, Root } from 'mdast';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
@@ -83,3 +86,5 @@ export function parseChunkInfos(
   });
   return dict;
 }
+
+```

--- a/packages/core/src/tangle.ts.md
+++ b/packages/core/src/tangle.ts.md
@@ -3,7 +3,7 @@
 ```ts main
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import type { ChunkDict } from './parser';
+import type { ChunkDict } from './parser.ts.md';
 import { escapeChunk } from './utils.ts.md';
 
 export async function tangle(

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { parseChunks } from '../src/parser';
+import { parseChunks } from '../src/parser.ts.md';
 import { resolveImport } from '../src/resolver.ts.md';
 import { tangle } from '../src/tangle.ts.md';
 

--- a/packages/core/test/parser.test.ts
+++ b/packages/core/test/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseChunkInfos, parseChunks } from '../src/parser';
+import { parseChunkInfos, parseChunks } from '../src/parser.ts.md';
 
 const md = [
   '# Title',


### PR DESCRIPTION
## Summary
- convert `parser.ts` to Markdown-flavored TS file
- update imports to new extension
- adjust documentation

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68562857cd0c83258956e579e6f8be73