### PR TITLE
Convert bundle.ts to ts.md

### DIFF
--- a/packages/core/src/bundle.ts.md
+++ b/packages/core/src/bundle.ts.md
@@ -1,3 +1,6 @@
+# Bundle
+
+```ts main
 import { Project, SyntaxKind } from 'ts-morph';
 import { parseChunkInfos } from './parser.ts.md';
 import { escapeChunk } from './utils.ts.md';
@@ -180,3 +183,4 @@ function removeExports(file: import('ts-morph').SourceFile) {
     ass.remove();
   }
 }
+```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,4 +4,4 @@ export { resolveImport } from './resolver.ts.md';
 export { detectCycle } from './graph.ts.md';
 export { tangle } from './tangle.ts.md';
 export * from './utils.ts.md';
-export { bundleMarkdown } from './bundle.js';
+export { bundleMarkdown } from './bundle.ts.md';

--- a/packages/core/test/bundle.test.ts
+++ b/packages/core/test/bundle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { bundleMarkdown } from '../src/bundle';
+import { bundleMarkdown } from '../src/bundle.ts.md';
 
 const md = [
   '# Test',


### PR DESCRIPTION
## Summary
- move `core`'s `bundle.ts` implementation into a Markdown file
- update references in source and tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685639299f4c832596c83b77cd235ef2