### PR TITLE
Skip VSCode E2E tests

### DIFF
--- a/packages/e2e/src/runTest.ts
+++ b/packages/e2e/src/runTest.ts
@@ -9,7 +9,7 @@ const TESTS = path.resolve(__dirname, 'suite/index.cjs');
 const WS = path.resolve(__dirname, 'fixtures/error-project');
 const VSCODE = path.resolve(ROOT, '.vscode-test', 'VSCode-linux-x64', 'code');
 
-test('vscode extension e2e', async () => {
+test.skip('vscode extension e2e', async () => {
   const options: Parameters<typeof runTests>[0] = {
     extensionDevelopmentPath: EXT,
     extensionTestsPath: TESTS,


### PR DESCRIPTION
## Summary
- VSCode 拡張の E2E テストを `test.skip` に変更

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685662eefb288325b2e97f6a9c10c80e