### PR TITLE
Add changeset for .test chunk exclusion

### DIFF
--- a/.changeset/ignore-test-chunks.md
+++ b/.changeset/ignore-test-chunks.md
@@ -1,0 +1,5 @@
+---
+"@sterashima78/ts-md-core": patch
+---
+
+ts.md のバンドル時に `.test` チャンクを除外するようにしました


### PR DESCRIPTION
## Summary
- add a changeset for ignoring `.test` chunks when bundling ts.md

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: InvalidOperationError)*
- `pnpm test` *(fails: Command failed with exit code 1)*
- `pnpm build` *(fails: Command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68567831d2748325b23c166dadf4a37f