### PR TITLE
Fix postbuild error in core package

### DIFF
--- a/packages/core/src/bundle.ts.md
+++ b/packages/core/src/bundle.ts.md
@@ -69,16 +69,18 @@ export function prefixDeclarations(
   file: import('ts-morph').SourceFile,
   prefix: string,
 ) {
-  for (const stmt of file.getStatements()) {
+  for (let i = 0; i < file.getStatements().length; i++) {
+    const stmt = file.getStatements()[i];
     if (stmt.getKind() === SyntaxKind.VariableStatement) {
       const vs = stmt.asKindOrThrow(SyntaxKind.VariableStatement);
       const exports: string[] = [];
+      const isExport = vs.hasExportKeyword();
       for (const decl of vs.getDeclarationList().getDeclarations()) {
         const name = decl.getNameNode();
         if (name.getKind() === SyntaxKind.Identifier) {
           const orig = name.getText();
           (name as import('ts-morph').Identifier).rename(`${prefix}${orig}`);
-          if (vs.hasExportKeyword())
+          if (isExport)
             exports.push(`${prefix}${orig} as ${orig}`);
         }
       }


### PR DESCRIPTION
## Summary
- avoid ts-morph node invalidation in prefixDeclarations

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68567e35bd488325a69bc6280bf855f4