### PR TITLE
Fix code block parsing in tests

### DIFF
--- a/packages/core/src/parser.ts.md
+++ b/packages/core/src/parser.ts.md
@@ -136,18 +136,18 @@ import { parseChunkInfos } from ':parseChunkInfos';
 const md = [
   '# Title',
   '',
-  '```ts foo',
+  ['`', '`', '`'].join('') + 'ts foo',
   'console.log(1)',
-  '```',
+  ['`', '`', '`'].join(''),
   '',
   '<!-- file: path/to/bar.ts -->',
-  '```ts bar',
+  ['`', '`', '`'].join('') + 'ts bar',
   'console.log(2)',
-  '```',
+  ['`', '`', '`'].join(''),
   '',
-  '```ts foo',
+  ['`', '`', '`'].join('') + 'ts foo',
   'console.log(3)',
-  '```',
+  ['`', '`', '`'].join(''),
 ].join('\n');
 
 describe('parseChunks', () => {

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -6,9 +6,18 @@ import { parseChunks } from '../src/parser.ts.md';
 import { resolveImport } from '../src/resolver.ts.md';
 import { tangle } from '../src/tangle.ts.md';
 
-const md = ['```ts main', "import './dep.ts.md'", '```'].join('\n');
+const tripleBacktick = '`' + '`' + '`';
+const md = [
+  `${tripleBacktick}ts main`,
+  "import './dep.ts.md'",
+  tripleBacktick,
+].join('\n');
 
-const depMd = ['```ts main', 'export const msg = 1', '```'].join('\n');
+const depMd = [
+  `${tripleBacktick}ts main`,
+  'export const msg = 1',
+  tripleBacktick,
+].join('\n');
 
 describe('integration', () => {
   it('roundtrip', async () => {


### PR DESCRIPTION
## Summary
- avoid writing triple backtick literals in integration tests
- remove raw triple backticks in parser test code

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck` *(fails: InvalidOperationError)*
- `pnpm test` *(fails: build step error)*
- `pnpm build` *(fails: build step error)*

------
https://chatgpt.com/codex/tasks/task_e_6856a7785150832584c133b46912726d