### PR TITLE
fix(core): avoid raw triple backticks in tests

### DIFF
--- a/packages/core/src/bundle.ts.md
+++ b/packages/core/src/bundle.ts.md
@@ -249,20 +249,20 @@ if (import.meta.vitest) {
 import { describe, expect, it } from 'vitest';
 import { bundleMarkdown } from ':bundleMarkdown';
 
-const md = [
-  '# Test',
-  '',
-  '```ts main',
-  "import { msg } from ':foo'",
-  'console.log(msg)',
-  '```',
-  '',
-  '```ts foo',
-  "export const msg = 'hi'",
-  '```',
-].join('\n');
-
 describe('bundleMarkdown', () => {
+  const md = [
+    '# Test',
+    '',
+    '`' + '`' + '`' + 'ts main',
+    "import { msg } from ':foo'",
+    'console.log(msg)',
+    '`' + '`' + '`',
+    '',
+    '`' + '`' + '`' + 'ts foo',
+    "export const msg = 'hi'",
+    '`' + '`' + '`',
+  ].join('\n');
+
   const code = bundleMarkdown(md, '/doc.ts.md');
   it('bundles chunks with prefix', () => {
     expect(code).toContain('const foo_msg');

--- a/packages/core/src/parser.ts.md
+++ b/packages/core/src/parser.ts.md
@@ -133,24 +133,24 @@ import { describe, expect, it } from 'vitest';
 import { parseChunks } from ':parseChunks';
 import { parseChunkInfos } from ':parseChunkInfos';
 
-const md = [
-  '# Title',
-  '',
-  '```ts foo',
-  'console.log(1)',
-  '```',
-  '',
-  '<!-- file: path/to/bar.ts -->',
-  '```ts bar',
-  'console.log(2)',
-  '```',
-  '',
-  '```ts foo',
-  'console.log(3)',
-  '```',
-].join('\n');
-
 describe('parseChunks', () => {
+  const md = [
+    '# Title',
+    '',
+    '`' + '`' + '`' + 'ts foo',
+    'console.log(1)',
+    '`' + '`' + '`',
+    '',
+    '<!-- file: path/to/bar.ts -->',
+    '`' + '`' + '`' + 'ts bar',
+    'console.log(2)',
+    '`' + '`' + '`',
+    '',
+    '`' + '`' + '`' + 'ts foo',
+    'console.log(3)',
+    '`' + '`' + '`',
+  ].join('\n');
+
   const dict = parseChunks(md, '/doc.ts.md');
   it('extracts named chunks', () => {
     expect(Object.keys(dict)).toEqual(['foo', 'path/to/bar.ts']);
@@ -159,6 +159,23 @@ describe('parseChunks', () => {
 });
 
 describe('parseChunkInfos', () => {
+  const md = [
+    '# Title',
+    '',
+    '`' + '`' + '`' + 'ts foo',
+    'console.log(1)',
+    '`' + '`' + '`',
+    '',
+    '<!-- file: path/to/bar.ts -->',
+    '`' + '`' + '`' + 'ts bar',
+    'console.log(2)',
+    '`' + '`' + '`',
+    '',
+    '`' + '`' + '`' + 'ts foo',
+    'console.log(3)',
+    '`' + '`' + '`',
+  ].join('\n');
+
   const dict = parseChunkInfos(md, '/doc.ts.md');
   it('includes start and end offsets', () => {
     expect(dict.foo.start).toBeLessThan(dict.foo.end);

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -6,12 +6,19 @@ import { parseChunks } from '../src/parser.ts.md';
 import { resolveImport } from '../src/resolver.ts.md';
 import { tangle } from '../src/tangle.ts.md';
 
-const md = ['```ts main', "import './dep.ts.md'", '```'].join('\n');
-
-const depMd = ['```ts main', 'export const msg = 1', '```'].join('\n');
-
 describe('integration', () => {
   it('roundtrip', async () => {
+    const md = [
+      '`' + '`' + '`' + 'ts main',
+      "import './dep.ts.md'",
+      '`' + '`' + '`',
+    ].join('\n');
+
+    const depMd = [
+      '`' + '`' + '`' + 'ts main',
+      'export const msg = 1',
+      '`' + '`' + '`',
+    ].join('\n');
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'int-'));
     const dict = parseChunks(md, path.join(tmp, 'doc.ts.md'));
     const depDict = parseChunks(depMd, path.join(tmp, 'dep.ts.md'));


### PR DESCRIPTION
## Summary
- update core test fixtures to avoid raw triple backticks

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6856a7785150832584c133b46912726d