### PR TITLE
Improve core ts.md docs

### DIFF
--- a/packages/core/src/tangle.ts.md
+++ b/packages/core/src/tangle.ts.md
@@ -2,15 +2,55 @@
 
 Markdown から抽出したチャンクを実際のファイルへ書き出すユーティリティです。
 
+## prepareOutputDir: 出力先準備
+
+書き出し先ディレクトリを作成します。
+
+```ts prepareOutputDir
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { escapeChunk } from './utils.ts.md';
+
+export async function prepareOutputDir(baseFile: string, outDir: string) {
+  const baseName = path.basename(baseFile, path.extname(baseFile));
+  const baseOut = path.join(outDir, baseName);
+  await fs.mkdir(baseOut, { recursive: true });
+  return baseOut;
+}
+```
+
+## writeChunk: ファイルへの書き出し
+
+単一チャンクを指定パスへ書き込みます。
+
+```ts writeChunk
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { escapeChunk } from './utils.ts.md';
+
+export async function writeChunk(
+  baseOut: string,
+  chunk: string,
+  code: string,
+  rename?: (chunk: string) => string,
+) {
+  const rel = rename ? rename(chunk) : `${escapeChunk(chunk)}.ts`;
+  const filePath = path.join(baseOut, rel);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, code, 'utf8');
+  return filePath;
+}
+```
+
 ## tangle: チャンクの書き出し
 
 指定ディレクトリ内にチャンクごとのファイルを生成します。返り値は書き出したファイルのパス一覧です。
 
 ```ts tangle
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import type { ChunkDict } from './parser.ts.md';
 import { escapeChunk } from './utils.ts.md';
+import { prepareOutputDir } from ':prepareOutputDir';
+import { writeChunk } from ':writeChunk';
 
 export async function tangle(
   dict: ChunkDict,
@@ -18,16 +58,16 @@ export async function tangle(
   outDir: string,
   rename?: (chunk: string) => string,
 ): Promise<string[]> {
-  const baseName = path.basename(baseFile, path.extname(baseFile));
-  const baseOut = path.join(outDir, baseName);
-  await fs.mkdir(baseOut, { recursive: true });
+  const baseOut = await prepareOutputDir(baseFile, outDir);
   const written: string[] = [];
 
   for (const [chunk, code] of Object.entries(dict)) {
-    const rel = rename ? rename(chunk) : `${escapeChunk(chunk)}.ts`;
-    const filePath = path.join(baseOut, rel);
-    await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, code, 'utf8');
+    const filePath = await writeChunk(
+      baseOut,
+      escapeChunk(chunk),
+      code,
+      rename,
+    );
     written.push(filePath);
   }
 


### PR DESCRIPTION
## Summary
- add helper modules to parser, tangle, graph, resolver, bundle
- restructure docs to describe elements of each function

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6856af04baf88325b66db9afa5b06bde