### PR TITLE
Remove ts entry from unplugin

### DIFF
--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -1,12 +1,10 @@
 # @sterashima78/ts-md-unplugin
 
-Bundler plugin to handle `.ts.md` files. It exposes wrappers for Vite, Rollup,
-Webpack and Esbuild.
+Bundler plugin to handle `.ts.md` files. It exposes wrappers for Vite, Rollup, Webpack and Esbuild.
 
-When a document is loaded, its chunks become virtual modules that can be
-imported via `#path:chunk` syntax.
+When a document is loaded, its chunks become virtual modules that can be imported via `#path:chunk` syntax.
 
 ## Structure
-- `src/index.ts` – common plugin logic
+- `src/index.ts.md` – common plugin logic
 - `src/vite.ts`, `src/rollup.ts`, `src/webpack.ts`, `src/esbuild.ts` – wrappers
 - `test/` – tests using the Rollup plugin

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -13,8 +13,9 @@
   },
   "files": ["dist"],
   "scripts": {
-    "build": "tsup src/index.ts src/vite.ts src/rollup.ts src/webpack.ts src/esbuild.ts --format esm --dts",
-    "typecheck": "tsc --noEmit",
+    "build": "tsup",
+    "postbuild": "ts-md-tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",
+    "typecheck": "ts-md-tsc -p tsconfig.json --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
@@ -22,6 +23,10 @@
     "@rollup/pluginutils": "^5.1.4",
     "rollup": "^4.41.1",
     "unplugin": "^2.3.5"
+  },
+  "devDependencies": {
+    "@sterashima78/ts-md-tsc": "0.1.0",
+    "ts-md-unplugin-build": "npm:@sterashima78/ts-md-unplugin@0.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/unplugin/src/esbuild.ts
+++ b/packages/unplugin/src/esbuild.ts
@@ -1,2 +1,2 @@
-import { unplugin } from './index';
+import { unplugin } from './index.ts.md';
 export default unplugin.esbuild();

--- a/packages/unplugin/src/index.ts.md
+++ b/packages/unplugin/src/index.ts.md
@@ -1,3 +1,8 @@
+# Unplugin
+
+`.ts.md` ファイルを処理するための共通ロジックを提供します。
+
+```ts main
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { createFilter } from '@rollup/pluginutils';
@@ -63,3 +68,4 @@ export const unplugin = createUnplugin((options: Options | undefined) => {
 });
 
 export default unplugin;
+```

--- a/packages/unplugin/src/rollup.ts
+++ b/packages/unplugin/src/rollup.ts
@@ -1,2 +1,2 @@
-import { unplugin } from './index';
+import { unplugin } from './index.ts.md';
 export default unplugin.rollup();

--- a/packages/unplugin/src/vite.ts
+++ b/packages/unplugin/src/vite.ts
@@ -1,2 +1,2 @@
-import { unplugin } from './index';
+import { unplugin } from './index.ts.md';
 export default unplugin.vite();

--- a/packages/unplugin/src/webpack.ts
+++ b/packages/unplugin/src/webpack.ts
@@ -1,2 +1,2 @@
-import { unplugin } from './index';
+import { unplugin } from './index.ts.md';
 export default unplugin.webpack();

--- a/packages/unplugin/test/index.test.ts
+++ b/packages/unplugin/test/index.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { Plugin } from 'rollup';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-let unpluginFactory: typeof import('../src').unplugin;
+let unpluginFactory: typeof import('../src/index.ts.md').unplugin;
 
 describe('ts-md-unplugin', () => {
   const dir = path.join(__dirname, 'fixtures');
@@ -18,7 +18,7 @@ describe('ts-md-unplugin', () => {
     );
     fs.writeFileSync(entry, "import './doc.ts.md';");
 
-    unpluginFactory = (await import('../src')).unplugin;
+    unpluginFactory = (await import('../src/index.ts.md')).unplugin;
   });
 
   afterAll(() => {

--- a/packages/unplugin/tsconfig.json
+++ b/packages/unplugin/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "compilerOptions": {
+    "allowArbitraryExtensions": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.ts.md"]
 }

--- a/packages/unplugin/tsup.config.ts
+++ b/packages/unplugin/tsup.config.ts
@@ -1,14 +1,16 @@
+import tsMd from 'ts-md-unplugin-build/esbuild';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: [
-    'src/index.ts',
+    'src/index.ts.md',
     'src/vite.ts',
     'src/rollup.ts',
     'src/webpack.ts',
     'src/esbuild.ts',
   ],
   format: ['esm'],
-  dts: true,
+  dts: false,
   clean: true,
+  esbuildPlugins: [tsMd],
 });

--- a/packages/unplugin/vitest.config.ts
+++ b/packages/unplugin/vitest.config.ts
@@ -1,0 +1,9 @@
+import tsMd from '@sterashima78/ts-md-unplugin/vite';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [tsMd],
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,13 @@ importers:
       unplugin:
         specifier: ^2.3.5
         version: 2.3.5
+    devDependencies:
+      '@sterashima78/ts-md-tsc':
+        specifier: 0.1.0
+        version: 0.1.0
+      ts-md-unplugin-build:
+        specifier: npm:@sterashima78/ts-md-unplugin@0.3.1
+        version: '@sterashima78/ts-md-unplugin@0.3.1'
 
   packages/vscode:
     dependencies:


### PR DESCRIPTION
## Summary
- delete `src/index.ts` in unplugin and build from Markdown source
- update wrapper imports and build config
- adjust tsconfig and add vitest config

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68577bd1b07c83259cecd86d1894dcb5