### PR TITLE
cli パッケージを ts.md 化

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,8 @@
   },
   "devDependencies": {
     "tsup": "^8",
-    "vitest": "^1"
+    "vitest": "^1",
+    "@sterashima78/ts-md-unplugin": "0.3.1"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com",

--- a/packages/cli/src/commands/check.ts.md
+++ b/packages/cli/src/commands/check.ts.md
@@ -1,3 +1,6 @@
+# check コマンド
+
+```ts main
 import {
   type TsMdVirtualFile,
   createTsMdPlugin,
@@ -6,7 +9,7 @@ import { createTypeScriptInferredChecker } from '@volar/kit';
 import type { Diagnostic, LanguagePlugin } from '@volar/language-service';
 import pc from 'picocolors';
 import type { URI } from 'vscode-uri';
-import { expandGlobs } from '../utils/globs';
+import { expandGlobs } from '../utils/globs.ts.md';
 
 export async function runCheck(globs: string[] = []) {
   const files = await expandGlobs(globs);
@@ -29,3 +32,4 @@ export async function runCheck(globs: string[] = []) {
 
   if (errorCount) process.exit(1);
 }
+```

--- a/packages/cli/src/commands/run.ts.md
+++ b/packages/cli/src/commands/run.ts.md
@@ -1,6 +1,9 @@
+# run コマンド
+
+```ts main
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { spawnNode } from '../utils/spawn';
+import { spawnNode } from '../utils/spawn.ts.md';
 
 export async function runTsMd(entryFile: string, nodeArgs: string[]) {
   const require = createRequire(import.meta.url);
@@ -12,3 +15,4 @@ export async function runTsMd(entryFile: string, nodeArgs: string[]) {
   const code = await spawnNode(args, { cwd: path.dirname(abs) });
   process.exit(code);
 }
+```

--- a/packages/cli/src/commands/tangle.ts.md
+++ b/packages/cli/src/commands/tangle.ts.md
@@ -1,7 +1,10 @@
+# tangle コマンド
+
+```ts main
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { parseChunks } from '@sterashima78/ts-md-core';
-import { expandGlobs } from '../utils/globs';
+import { expandGlobs } from '../utils/globs.ts.md';
 
 export async function runTangle(inputGlobs: string[], outDir = 'dist') {
   const files = await expandGlobs(inputGlobs);
@@ -21,3 +24,4 @@ export async function runTangle(inputGlobs: string[], outDir = 'dist') {
     }
   }
 }
+```

--- a/packages/cli/src/index.ts.md
+++ b/packages/cli/src/index.ts.md
@@ -1,8 +1,11 @@
+# CLI Entrypoint
+
+```ts main
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { runCheck } from './commands/check';
-import { runTsMd } from './commands/run';
-import { runTangle } from './commands/tangle';
+import { runCheck } from './commands/check.ts.md';
+import { runTsMd } from './commands/run.ts.md';
+import { runTangle } from './commands/tangle.ts.md';
 
 const program = new Command('tsmd');
 
@@ -31,3 +34,4 @@ program
   });
 
 program.parse();
+```

--- a/packages/cli/src/utils/globs.ts.md
+++ b/packages/cli/src/utils/globs.ts.md
@@ -1,5 +1,9 @@
+# glob 展開
+
+```ts main
 import fg from 'fast-glob';
 
 export async function expandGlobs(globs: string[]): Promise<string[]> {
   return fg(globs.length ? globs : ['**/*.ts.md'], { absolute: true });
 }
+```

--- a/packages/cli/src/utils/spawn.ts.md
+++ b/packages/cli/src/utils/spawn.ts.md
@@ -1,3 +1,6 @@
+# Node プロセス実行
+
+```ts main
 import { spawn } from 'node:child_process';
 
 export function spawnNode(
@@ -12,3 +15,4 @@ export function spawnNode(
     p.on('close', (code) => res(code ?? 0));
   });
 }
+```

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "declaration": false
+    "declaration": false,
+    "allowArbitraryExtensions": true
   },
-  "include": ["src"]
+  "include": ["src/**/*.ts", "src/**/*.ts.md"]
 }

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,7 +1,8 @@
+import tsMd from '@sterashima78/ts-md-unplugin/esbuild';
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts.md'],
   target: 'node18',
   format: ['esm'],
   shims: false,
@@ -20,4 +21,5 @@ export default defineConfig({
     'vscode-uri',
     'tsx/esm',
   ],
+  esbuildPlugins: [tsMd],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
         specifier: ^4
         version: 4.19.4
     devDependencies:
+      '@sterashima78/ts-md-unplugin':
+        specifier: 0.3.1
+        version: 0.3.1
       tsup:
         specifier: ^8
         version: 8.5.0(postcss@8.5.4)(tsx@4.19.4)(typescript@5.8.3)


### PR DESCRIPTION
## Summary
- ts.md 形式に移行するため CLI ソースを `*.ts.md` に変更
- tsup 設定を更新して ts-md-unplugin を利用
- tsconfig で `.ts.md` を解釈するように設定
- CLI パッケージの devDependency に ts-md-unplugin を追加

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6857df5fb5108325b3b3404d2d54a9bd