### PR TITLE
Add ts.md tests for cli package

### DIFF
--- a/packages/cli/src/utils/globs.ts.md
+++ b/packages/cli/src/utils/globs.ts.md
@@ -1,9 +1,51 @@
 # glob 展開
 
-```ts main
+```ts expandGlobs
 import fg from 'fast-glob';
 
 export async function expandGlobs(globs: string[]): Promise<string[]> {
   return fg(globs.length ? globs : ['**/*.ts.md'], { absolute: true });
 }
+```
+
+## 公開インタフェース
+
+```ts main
+export { expandGlobs } from ':expandGlobs';
+
+if (import.meta.vitest) {
+  await import(':expandGlobs.test');
+}
+```
+
+## Tests
+
+```ts expandGlobs.test
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { expandGlobs } from ':expandGlobs';
+
+describe('expandGlobs', () => {
+  const dir = path.join(process.cwd(), 'test', 'fixtures', 'expand-globs');
+  const files = [
+    path.join(dir, 'a.ts.md'),
+    path.join(dir, 'nested', 'b.ts.md'),
+  ];
+
+  beforeAll(async () => {
+    await fs.mkdir(path.join(dir, 'nested'), { recursive: true });
+    await fs.writeFile(files[0], '', 'utf8');
+    await fs.writeFile(files[1], '', 'utf8');
+  });
+
+  afterAll(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns matching files', async () => {
+    const result = await expandGlobs([path.join(dir, '**/*.ts.md')]);
+    expect(result.sort()).toEqual(files.sort());
+  });
+});
 ```

--- a/packages/cli/src/utils/spawn.ts.md
+++ b/packages/cli/src/utils/spawn.ts.md
@@ -1,6 +1,6 @@
 # Node プロセス実行
 
-```ts main
+```ts spawnNode
 import { spawn } from 'node:child_process';
 
 export function spawnNode(
@@ -15,4 +15,34 @@ export function spawnNode(
     p.on('close', (code) => res(code ?? 0));
   });
 }
+```
+
+## 公開インタフェース
+
+```ts main
+export { spawnNode } from ':spawnNode';
+
+if (import.meta.vitest) {
+  await import(':spawnNode.test');
+}
+```
+
+## Tests
+
+```ts spawnNode.test
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { spawnNode } from ':spawnNode';
+
+describe('spawnNode', () => {
+  it('executes Node process', async () => {
+    const dir = await fs.mkdtemp(path.join(process.cwd(), 'spawn-'));
+    const file = path.join(dir, 'index.js');
+    await fs.writeFile(file, "console.log('ok')", 'utf8');
+    const code = await spawnNode([file], { cwd: dir });
+    expect(code).toBe(0);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});
 ```

--- a/packages/cli/test/placeholder.test.ts
+++ b/packages/cli/test/placeholder.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest';
-
-describe('placeholder', () => {
-  it('works', () => {
-    expect(1).toBe(1);
-  });
-});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,7 +1,15 @@
+import tsMd from '@sterashima78/ts-md-unplugin/vite';
 import { defineConfig } from 'vitest/config';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const r = (p: string) => resolve(dirname(fileURLToPath(import.meta.url)), p);
 
 export default defineConfig({
+  root: dirname(fileURLToPath(import.meta.url)),
+  plugins: [tsMd],
   test: {
     globals: true,
+    include: [r('src/utils/globs.ts.md'), r('src/utils/spawn.ts.md')],
   },
 });


### PR DESCRIPTION
## Summary
- implement globs and spawnNode tests inside ts.md
- drop old test directory
- configure vitest to run these ts.md tests

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: ENOENT: no such file or directory, open '/src/utils/globs.ts.md')*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6857e971fb14832596c800c14ab02184