### PR TITLE
Move CLI tests into ts.md

### DIFF
--- a/packages/cli/src/utils/globs.ts.md
+++ b/packages/cli/src/utils/globs.ts.md
@@ -1,9 +1,40 @@
 # glob 展開
 
-```ts main
+```ts expandGlobs
 import fg from 'fast-glob';
 
 export async function expandGlobs(globs: string[]): Promise<string[]> {
   return fg(globs.length ? globs : ['**/*.ts.md'], { absolute: true });
 }
+```
+
+## 公開インタフェース
+
+```ts main
+export { expandGlobs } from ':expandGlobs';
+
+if (import.meta.vitest) {
+  await import(':expandGlobs.test');
+}
+```
+
+## Tests
+
+```ts expandGlobs.test
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { expandGlobs } from ':expandGlobs';
+
+describe('expandGlobs', () => {
+  it('returns matched files', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'globs-'));
+    const file = path.join(tmp, 'doc.ts.md');
+    await fs.writeFile(file, '', 'utf8');
+    const files = await expandGlobs([`${tmp}/*.ts.md`]);
+    expect(files).toEqual([file]);
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+});
 ```

--- a/packages/cli/src/utils/spawn.ts.md
+++ b/packages/cli/src/utils/spawn.ts.md
@@ -1,6 +1,6 @@
 # Node プロセス実行
 
-```ts main
+```ts spawnNode
 import { spawn } from 'node:child_process';
 
 export function spawnNode(
@@ -15,4 +15,28 @@ export function spawnNode(
     p.on('close', (code) => res(code ?? 0));
   });
 }
+```
+
+## 公開インタフェース
+
+```ts main
+export { spawnNode } from ':spawnNode';
+
+if (import.meta.vitest) {
+  await import(':spawnNode.test');
+}
+```
+
+## Tests
+
+```ts spawnNode.test
+import { describe, expect, it } from 'vitest';
+import { spawnNode } from ':spawnNode';
+
+describe('spawnNode', () => {
+  it('returns exit code', async () => {
+    const code = await spawnNode(['-e', 'console.log("ok")']);
+    expect(code).toBe(0);
+  });
+});
 ```

--- a/packages/cli/test/placeholder.test.ts
+++ b/packages/cli/test/placeholder.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest';
-
-describe('placeholder', () => {
-  it('works', () => {
-    expect(1).toBe(1);
-  });
-});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,7 +1,16 @@
+import tsMd from '@sterashima78/ts-md-unplugin/vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  root: __dirname,
+  plugins: [tsMd],
   test: {
     globals: true,
+    include: ['src/utils/*.ts.md'],
+  },
+  resolve: {
+    alias: {
+      '/src/': `${__dirname}/src/`,
+    },
   },
 });


### PR DESCRIPTION
## Summary
- remove `packages/cli/test`
- add inline tests for `expandGlobs` and `spawnNode`
- update CLI vitest config to run ts.md tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6857e971fb14832596c800c14ab02184