### PR TITLE
Add Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "@sterashima78/ts-md-unplugin",
+        "@sterashima78/ts-md-tsc"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Renovate を設定
  - `@sterashima78/ts-md-unplugin` と `@sterashima78/ts-md-tsc` を無視
  - GitHub Actions には commit ID を付けるため `pinDigests` を有効化

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6859b8f96c34832582a9952fb9f32d69