### PR TITLE
Add packages read permission to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
       pages: write
       id-token: write
+      packages: read
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2


### PR DESCRIPTION
## Summary
- docs ワークフローで GitHub Packages を利用するために `packages: read` パーミッションを追加

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6859bd474e5483259fe82d0b6b0db5bb