### PR TITLE
Add Renovate host rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": ["config:base"],
+  "hostRules": [
+    {
+      "hostType": "npm",
+      "matchHost": "npm.pkg.github.com",
+      "token": "{{ secrets.GH_PKG_TOKEN }}"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
## Summary
- npm.pkg.github.com用のhostRulesを追加しました

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a6f226c908325a796c599132b4e23