### PR TITLE
Add NODE_AUTH_TOKEN env in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,9 +9,12 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  packages: read
 
 jobs:
   build:
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add `packages: read` to the workflow permissions
- set up `NODE_AUTH_TOKEN` for the build job

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a8fd025f483258e71bd9c906c3c71