### PR TITLE
docs: set base path

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -3,6 +3,7 @@ import starlight from '@astrojs/starlight';
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
+  base: '/ts-md/',
   integrations: [
     starlight({
       title: 'TS-MD Docs',


### PR DESCRIPTION
## Summary
- docsサイトのベースパスを`/ts-md/`に設定

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a9609c40c8325923f30cac163a002