### PR TITLE
chore: biome migrate で lint 修正

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -7,20 +7,30 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": []
+    "includes": ["**"]
   },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
     "indentWidth": 2
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "style": {
+        "noParameterAssign": "error",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "noUnusedTemplateLiteral": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error",
+        "noUselessElse": "error"
+      }
     }
   },
   "javascript": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,10 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist", "index.js"],
+  "files": [
+    "dist",
+    "index.js"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,9 @@
   "exports": {
     ".": "./dist/index.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "postbuild": "ts-md-tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,7 @@
-export { parseChunks, parseChunkInfos } from './parser.ts.md';
-export type { ChunkInfo } from './parser.ts.md';
-export { resolveImport } from './resolver.ts.md';
+export { bundleMarkdown } from './bundle.ts.md';
 export { detectCycle } from './graph.ts.md';
+export type { ChunkInfo } from './parser.ts.md';
+export { parseChunkInfos, parseChunks } from './parser.ts.md';
+export { resolveImport } from './resolver.ts.md';
 export { tangle } from './tangle.ts.md';
 export * from './utils.ts.md';
-export { bundleMarkdown } from './bundle.ts.md';

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "postbuild": "ts-md-tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",

--- a/packages/ls-core/package.json
+++ b/packages/ls-core/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "postbuild": "ts-md-tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",

--- a/packages/ls-core/src/index.ts
+++ b/packages/ls-core/src/index.ts
@@ -1,8 +1,8 @@
 export { tsMdLanguagePlugin as createTsMdPlugin } from './plugin.ts.md';
-export type { TsMdVirtualFile } from './virtual-file.ts.md';
 export {
-  createTsMdLanguageService,
   collectDiagnostics,
+  createTsMdLanguageService,
   type TsMdDiagnostic,
   type TsMdDiagnosticsResult,
 } from './service.ts.md';
+export type { TsMdVirtualFile } from './virtual-file.ts.md';

--- a/packages/monaco/package.json
+++ b/packages/monaco/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "typecheck": "ts-md-tsc -p tsconfig.json --noEmit",

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,2 +1,3 @@
 import './app.ts.md';
+
 export * from './mini-core/index.js';

--- a/packages/sandbox/src/mini-core/index.ts
+++ b/packages/sandbox/src/mini-core/index.ts
@@ -1,4 +1,4 @@
+export { detectCycle } from './graph.ts.md';
 export { parse } from './parser.ts.md';
 export { resolveImport } from './resolver.ts.md';
-export { detectCycle } from './graph.ts.md';
 export { tangle } from './tangle.ts.md';

--- a/packages/sandbox/test/app.test.ts
+++ b/packages/sandbox/test/app.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
+
 // cross-file chunk imports are not supported
 
 describe('app.ts.md', () => {

--- a/packages/tsc/package.json
+++ b/packages/tsc/package.json
@@ -6,7 +6,10 @@
     "ts-md-tsc": "./index.js"
   },
   "main": "dist/index.js",
-  "files": ["dist", "index.js"],
+  "files": [
+    "dist",
+    "index.js"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -11,7 +11,9 @@
     "./webpack": "./dist/webpack.js",
     "./esbuild": "./dist/esbuild.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "postbuild": "ts-md-tsc -p tsconfig.json --emitDeclarationOnly --outDir dist",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -6,7 +6,9 @@
   "engines": {
     "vscode": "^1.85.0"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup && tsx scripts/postbuild.ts",
     "package": "tsx scripts/package.ts",
@@ -29,14 +31,23 @@
     "vsce": "^2.15.0",
     "@sterashima78/ts-md-tsc": "0.1.0"
   },
-  "activationEvents": ["onLanguage:ts-md"],
+  "activationEvents": [
+    "onLanguage:ts-md"
+  ],
   "contributes": {
     "languages": [
       {
         "id": "ts-md",
-        "aliases": ["TypeScript Markdown", "ts-md"],
-        "extensions": [".ts.md"],
-        "filenamePatterns": ["*.ts.md"],
+        "aliases": [
+          "TypeScript Markdown",
+          "ts-md"
+        ],
+        "extensions": [
+          ".ts.md"
+        ],
+        "filenamePatterns": [
+          "*.ts.md"
+        ],
         "configuration": "./dist/language-configuration.json"
       }
     ],

--- a/packages/vscode/src/commands.ts
+++ b/packages/vscode/src/commands.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { LanguageClient } from '@volar/vscode/node';
 import * as vscode from 'vscode';
+
 const exec = promisify(execFile);
 
 export function registerCommands(

--- a/packages/vscode/src/server/server.ts
+++ b/packages/vscode/src/server/server.ts
@@ -1,17 +1,17 @@
 import {
-  type TsMdDiagnostic,
   collectDiagnostics,
+  type TsMdDiagnostic,
 } from '@sterashima78/ts-md-ls-core';
 import { provider as fileSystemProvider } from '@volar/language-server/lib/fileSystemProviders/node';
 import { createSimpleProject } from '@volar/language-server/lib/project/simpleProject';
 import { createServerBase } from '@volar/language-server/lib/server';
 import type { SnapshotDocument } from '@volar/language-server/lib/utils/snapshotDocument';
 import {
+  createConnection,
   DiagnosticSeverity,
   type ExperimentalFeatures,
   type ServerCapabilities,
   TextDocumentSyncKind,
-  createConnection,
 } from '@volar/language-server/node';
 import { URI } from 'vscode-uri';
 


### PR DESCRIPTION
## Summary
- `pnpm exec biome migrate --write` を実行して設定を最新化
- `pnpm exec biome check --write --unsafe` で自動修正

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a9a23f5fc8325a52f08a81973381f