### PR TITLE
chore: group volar packages in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,10 @@
       "enabled": false
     },
     {
+      "matchPackagePatterns": ["^@volar/"],
+      "groupName": "volar"
+    },
+    {
       "matchManagers": ["github-actions"],
       "pinDigests": true
     }


### PR DESCRIPTION
## Summary
- renovate設定を更新し、`@volar` スコープの依存をまとめてPRするように変更

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a9d2b48148325823548bfe62d093e