### PR TITLE
docs: update index content

### DIFF
--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -1,16 +1,16 @@
 ---
-title: TS-MDへようこそ
-description: TS-MD プロジェクトのドキュメントサイトです。
+title: パッケージ一覧
 template: splash
-hero:
-  tagline: TS-MD ドキュメントへようこそ
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-## 使い方
-
 <CardGrid stagger>
-  <Card title="パッケージ一覧" icon="package">左のサイドバーから各パッケージのドキュメントを参照してください。</Card>
-  <Card title="リポジトリ" icon="github"><a href="https://github.com/sterashima78/ts-md">GitHub</a></Card>
+  <Card title="CLI" icon="package"><a href="/packages/cli/README">CLI README</a></Card>
+  <Card title="Core" icon="package"><a href="/packages/core/README">Core README</a></Card>
+  <Card title="Loader" icon="package"><a href="/packages/loader/README">Loader README</a></Card>
+  <Card title="LS-Core" icon="package"><a href="/packages/ls-core/README">LS-Core README</a></Card>
+  <Card title="Sandbox" icon="package"><a href="/packages/sandbox/README">Sandbox README</a></Card>
+  <Card title="Unplugin" icon="package"><a href="/packages/unplugin/README">Unplugin README</a></Card>
+  <Card title="GitHub" icon="github"><a href="https://github.com/sterashima78/ts-md">GitHub</a></Card>
 </CardGrid>

--- a/packages/docs/src/packagesLoader.ts
+++ b/packages/docs/src/packagesLoader.ts
@@ -7,7 +7,7 @@ import fg from 'fast-glob';
 export function packagesLoader(): Loader {
   const root = new URL('../../..', import.meta.url);
   const pattern =
-    'packages/{cli,core,loader,ls-core,sandbox,unplugin}/src/**/*.ts.md';
+    'packages/{cli,core,loader,ls-core,sandbox,unplugin}/{README.md,src/**/*.ts.md}';
 
   return {
     name: 'packages-loader',
@@ -20,9 +20,12 @@ export function packagesLoader(): Loader {
         const heading = body.match(/^#\s+(.*)/m);
         const title = heading ? heading[1].trim() : undefined;
         const match = entry.match(/^packages\/([^/]+)\/src\/(.*)\.ts\.md$/);
+        const readmeMatch = entry.match(/^packages\/([^/]+)\/README\.md$/);
         const id = match
           ? `packages/${match[1]}/${match[2]}`
-          : entry.replace(/\.ts\.md$/, '');
+          : readmeMatch
+            ? `packages/${readmeMatch[1]}/README`
+            : entry.replace(/\.ts\.md$/, '').replace(/\.md$/, '');
         const data = await ctx.parseData({
           id,
           data: { title },


### PR DESCRIPTION
## Summary
- update packagesLoader to include README files
- simplify docs index page with links to each README

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685a9f35c8388325984ea1cce22f1093