### PR TITLE
Exclude sandbox docs

### DIFF
--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -10,7 +10,6 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   <Card title="Core" icon="package"><a href="/packages/core/README">Core README</a></Card>
   <Card title="Loader" icon="package"><a href="/packages/loader/README">Loader README</a></Card>
   <Card title="LS-Core" icon="package"><a href="/packages/ls-core/README">LS-Core README</a></Card>
-  <Card title="Sandbox" icon="package"><a href="/packages/sandbox/README">Sandbox README</a></Card>
   <Card title="Unplugin" icon="package"><a href="/packages/unplugin/README">Unplugin README</a></Card>
   <Card title="GitHub" icon="github"><a href="https://github.com/sterashima78/ts-md">GitHub</a></Card>
 </CardGrid>

--- a/packages/docs/src/packagesLoader.ts
+++ b/packages/docs/src/packagesLoader.ts
@@ -7,7 +7,7 @@ import fg from 'fast-glob';
 export function packagesLoader(): Loader {
   const root = new URL('../../..', import.meta.url);
   const pattern =
-    'packages/{cli,core,loader,ls-core,sandbox,unplugin}/{README.md,src/**/*.ts.md}';
+    'packages/{cli,core,loader,ls-core,unplugin}/{README.md,src/**/*.ts.md}';
 
   return {
     name: 'packages-loader',


### PR DESCRIPTION
## Summary
- remove `sandbox` from package loader pattern
- update docs site to remove sandbox link

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685b13980e6883259f63be56df0e0fcf