### PR TITLE
Fix docs homepage links

### DIFF
--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -6,11 +6,11 @@ template: splash
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
-  <Card title="CLI" icon="package"><a href="/packages/cli/README">CLI README</a></Card>
-  <Card title="Core" icon="package"><a href="/packages/core/README">Core README</a></Card>
-  <Card title="Loader" icon="package"><a href="/packages/loader/README">Loader README</a></Card>
-  <Card title="LS-Core" icon="package"><a href="/packages/ls-core/README">LS-Core README</a></Card>
-  <Card title="Sandbox" icon="package"><a href="/packages/sandbox/README">Sandbox README</a></Card>
-  <Card title="Unplugin" icon="package"><a href="/packages/unplugin/README">Unplugin README</a></Card>
+  <Card title="CLI" icon="package"><a href="packages/cli/README">CLI README</a></Card>
+  <Card title="Core" icon="package"><a href="packages/core/README">Core README</a></Card>
+  <Card title="Loader" icon="package"><a href="packages/loader/README">Loader README</a></Card>
+  <Card title="LS-Core" icon="package"><a href="packages/ls-core/README">LS-Core README</a></Card>
+  <Card title="Sandbox" icon="package"><a href="packages/sandbox/README">Sandbox README</a></Card>
+  <Card title="Unplugin" icon="package"><a href="packages/unplugin/README">Unplugin README</a></Card>
   <Card title="GitHub" icon="github"><a href="https://github.com/sterashima78/ts-md">GitHub</a></Card>
 </CardGrid>


### PR DESCRIPTION
## Summary
- docsトップページのリンクを相対パスに修正

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685b13b5645483258a7f75d6f529c3d2