### PR TITLE
Sandbox を docs の収集対象から除外

### DIFF
--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -10,7 +10,6 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
   <Card title="Core" icon="package"><a href="packages/core/README">Core README</a></Card>
   <Card title="Loader" icon="package"><a href="packages/loader/README">Loader README</a></Card>
   <Card title="LS-Core" icon="package"><a href="packages/ls-core/README">LS-Core README</a></Card>
-  <Card title="Sandbox" icon="package"><a href="packages/sandbox/README">Sandbox README</a></Card>
   <Card title="Unplugin" icon="package"><a href="packages/unplugin/README">Unplugin README</a></Card>
   <Card title="GitHub" icon="github"><a href="https://github.com/sterashima78/ts-md">GitHub</a></Card>
 </CardGrid>

--- a/packages/docs/src/packagesLoader.ts
+++ b/packages/docs/src/packagesLoader.ts
@@ -7,7 +7,7 @@ import fg from 'fast-glob';
 export function packagesLoader(): Loader {
   const root = new URL('../../..', import.meta.url);
   const pattern =
-    'packages/{cli,core,loader,ls-core,sandbox,unplugin}/{README.md,src/**/*.ts.md}';
+    'packages/{cli,core,loader,ls-core,unplugin}/{README.md,src/**/*.ts.md}';
 
   return {
     name: 'packages-loader',


### PR DESCRIPTION
## 概要
ドキュメントサイトで読み込むパッケージから sandbox を除外しました。

## 変更点
- `packagesLoader.ts` のパターンから `sandbox` を削除
- トップページのカードから Sandbox を削除

## テスト結果
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
すべて成功することを確認しました。

------
https://chatgpt.com/codex/tasks/task_e_685b183ccf0883258dd8a920cf638bf7