### PR TITLE
Unskip VS Code e2e test

### DIFF
--- a/packages/e2e/src/runTest.ts
+++ b/packages/e2e/src/runTest.ts
@@ -9,7 +9,7 @@ const TESTS = path.resolve(__dirname, 'suite/index.cjs');
 const WS = path.resolve(__dirname, 'fixtures/error-project');
 const VSCODE = path.resolve(ROOT, '.vscode-test', 'VSCode-linux-x64', 'code');
 
-test.skip('vscode extension e2e', async () => {
+test('vscode extension e2e', async () => {
   const options: Parameters<typeof runTests>[0] = {
     extensionDevelopmentPath: EXT,
     extensionTestsPath: TESTS,

--- a/packages/vscode/src/server/server.ts
+++ b/packages/vscode/src/server/server.ts
@@ -1,7 +1,4 @@
-import {
-  collectDiagnostics,
-  type TsMdDiagnostic,
-} from '@sterashima78/ts-md-ls-core';
+import type { TsMdDiagnostic } from '@sterashima78/ts-md-ls-core';
 import { provider as fileSystemProvider } from '@volar/language-server/lib/fileSystemProviders/node';
 import { createSimpleProject } from '@volar/language-server/lib/project/simpleProject';
 import { createServerBase } from '@volar/language-server/lib/server';
@@ -37,6 +34,7 @@ documents.onDidChangeContent((e) => void sendDiagnostics(e.document));
 
 async function sendDiagnostics(doc: SnapshotDocument) {
   const file = URI.parse(doc.uri).fsPath;
+  const { collectDiagnostics } = await import('@sterashima78/ts-md-ls-core');
   const result = await collectDiagnostics([file]);
   const diagnostics = (result[file] ?? []).map((d: TsMdDiagnostic) => ({
     range: d.range,


### PR DESCRIPTION
## Summary
- VS Code の e2e テスト `test.skip` を解除
- サーバーが ES モジュールを require できず失敗していたため `import()` を使うよう修正

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685d305ef0a48325bda0256b2814ca0f