### PR TITLE
ts.md ドキュメント整理

### DIFF
--- a/packages/cli/src/commands/check.ts.md
+++ b/packages/cli/src/commands/check.ts.md
@@ -1,6 +1,8 @@
 # check コマンド
 
-```ts main
+`.ts.md` ファイルを型検査する `runCheck` 関数を公開します。
+
+```ts runCheck
 import {
   type TsMdVirtualFile,
   createTsMdPlugin,
@@ -32,4 +34,10 @@ export async function runCheck(globs: string[] = []) {
 
   if (errorCount) process.exit(1);
 }
+```
+
+## 公開インタフェース
+
+```ts main
+export { runCheck } from ':runCheck';
 ```

--- a/packages/cli/src/commands/run.ts.md
+++ b/packages/cli/src/commands/run.ts.md
@@ -1,6 +1,8 @@
 # run コマンド
 
-```ts main
+`runTsMd` 関数は `.ts.md` ファイルを Node で実行するためのヘルパです。
+
+```ts runTsMd
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { spawnNode } from '../utils/spawn.ts.md';
@@ -15,4 +17,10 @@ export async function runTsMd(entryFile: string, nodeArgs: string[]) {
   const code = await spawnNode(args, { cwd: path.dirname(abs) });
   process.exit(code);
 }
+```
+
+## 公開インタフェース
+
+```ts main
+export { runTsMd } from ':runTsMd';
 ```

--- a/packages/cli/src/commands/tangle.ts.md
+++ b/packages/cli/src/commands/tangle.ts.md
@@ -1,6 +1,8 @@
 # tangle コマンド
 
-```ts main
+ドキュメントからコードチャンクを抽出して実ファイルへ展開する処理です。
+
+```ts runTangle
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { parseChunks } from '@sterashima78/ts-md-core';
@@ -24,4 +26,10 @@ export async function runTangle(inputGlobs: string[], outDir = 'dist') {
     }
   }
 }
+```
+
+## 公開インタフェース
+
+```ts main
+export { runTangle } from ':runTangle';
 ```

--- a/packages/cli/src/index.ts.md
+++ b/packages/cli/src/index.ts.md
@@ -1,37 +1,49 @@
 # CLI Entrypoint
 
-```ts main
-#!/usr/bin/env node
+コマンド登録をまとめた `createCli` 関数を定義し、`main` ブロックではそれを実行するだけにします。
+
+```ts createCli
 import { Command } from 'commander';
 import { runCheck } from './commands/check.ts.md';
 import { runTsMd } from './commands/run.ts.md';
 import { runTangle } from './commands/tangle.ts.md';
 
-const program = new Command('tsmd');
+export function createCli() {
+  const program = new Command('tsmd');
 
-program
-  .command('check [args...]')
-  .allowUnknownOption()
-  .description('tsc と同様に .ts.md を型チェックします')
-  .action(() => runCheck());
+  program
+    .command('check [args...]')
+    .allowUnknownOption()
+    .description('tsc と同様に .ts.md を型チェックします')
+    .action(() => runCheck());
 
-program
-  .command('tangle [globs...]')
-  .option('-o, --outDir <dir>', 'output directory', 'dist')
-  .description('Extract code chunks to real files')
-  .action((globs: string[], opts: { outDir: string }) =>
-    runTangle(globs, opts.outDir),
-  );
+  program
+    .command('tangle [globs...]')
+    .option('-o, --outDir <dir>', 'output directory', 'dist')
+    .description('Extract code chunks to real files')
+    .action((globs: string[], opts: { outDir: string }) =>
+      runTangle(globs, opts.outDir),
+    );
 
-program
-  .command('run <file>')
-  .allowUnknownOption()
-  .description('Execute a .ts.md file with Node')
-  .action((file: string, _opts: unknown, cmd: Command) => {
-    const rest =
-      cmd.parent?.args.slice(cmd.parent.args.indexOf('run') + 2) ?? [];
-    runTsMd(file, rest);
-  });
+  program
+    .command('run <file>')
+    .allowUnknownOption()
+    .description('Execute a .ts.md file with Node')
+    .action((file: string, _opts: unknown, cmd: Command) => {
+      const rest =
+        cmd.parent?.args.slice(cmd.parent.args.indexOf('run') + 2) ?? [];
+      runTsMd(file, rest);
+    });
 
-program.parse();
+  return program;
+}
+```
+
+## 公開インタフェース
+
+```ts main
+#!/usr/bin/env node
+export { createCli } from ':createCli';
+
+createCli().parse();
 ```


### PR DESCRIPTION
## Summary
- CLI の ts.md ファイルを関数単位のコードブロックに整理

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685d46ad820c83259221052c0db1d8e8