### PR TITLE
ts.md ファイル整理

### DIFF
--- a/packages/ls-core/src/parsers.ts.md
+++ b/packages/ls-core/src/parsers.ts.md
@@ -1,10 +1,14 @@
 # Parsers
 
-```ts main
-import { parseChunkInfos, parseChunks } from '@sterashima78/ts-md-core';
+Language service で使用する簡易パーサー群です。
+
+## getChunkDict: チャンク辞書の生成
+
+```ts getChunkDict
+import { parseChunks } from '@sterashima78/ts-md-core';
 import type ts from 'typescript';
 
-/** キャッシュ付きで Markdown をチャンク辞書へ */
+/** キャッシュ付きで Markdown をチャンク辞書へ変換 */
 export function getChunkDict(snapshot: ts.IScriptSnapshot, uri: string) {
   const text = snapshot.getText(0, snapshot.getLength());
   const chunks = parseChunks(text, uri);
@@ -14,11 +18,25 @@ export function getChunkDict(snapshot: ts.IScriptSnapshot, uri: string) {
   }
   return dict;
 }
+```
 
-export type { ChunkInfo } from '@sterashima78/ts-md-core';
+## getChunkInfoDict: 位置情報付き辞書
+
+```ts getChunkInfoDict
+import { parseChunkInfos } from '@sterashima78/ts-md-core';
+import type ts from 'typescript';
+import type { ChunkInfo } from '@sterashima78/ts-md-core';
 
 export function getChunkInfoDict(snapshot: ts.IScriptSnapshot, uri: string) {
   const text = snapshot.getText(0, snapshot.getLength());
   return parseChunkInfos(text, uri);
 }
+```
+
+## 公開インタフェース
+
+```ts main
+export { getChunkDict } from ':getChunkDict';
+export { getChunkInfoDict } from ':getChunkInfoDict';
+export type { ChunkInfo } from '@sterashima78/ts-md-core';
 ```


### PR DESCRIPTION
## Summary
- unplugin の ts.md を関数毎のチャンクに分割
- ls-core の parsers.ts.md を整理

## Testing
- `pnpm i`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685d46ad820c83259221052c0db1d8e8