### PR TITLE
Refactor loader documentation

### DIFF
--- a/packages/loader/tsup.config.ts
+++ b/packages/loader/tsup.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
   clean: true,
   target: 'node18',
   outExtension: () => ({ js: '.js' }),
-  bundle: false,
+  bundle: true,
+  splitting: false,
+  external: ['typescript'],
   esbuildPlugins: [tsMd],
 });


### PR DESCRIPTION
## Summary
- split `packages/loader` literate file into smaller chunks
- bundle loader output to single file
- mark `typescript` as external to avoid dynamic require errors

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685f1c2cab108325b3b96f96112d56da