### PR TITLE
Node.js標準APIへの置換とpnpm catalogの整理

### DIFF
--- a/.changeset/quiet-mice-glob.md
+++ b/.changeset/quiet-mice-glob.md
@@ -1,0 +1,5 @@
+---
+'@sterashima78/ts-md-cli': minor
+---
+
+Node.js 24 の標準 glob と引数 parser を使用し、外部 CLI utility への依存を削除しました。

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,9 +20,10 @@
     "@sterashima78/ts-md-core": "workspace:*",
     "@sterashima78/ts-md-loader": "workspace:*",
     "@sterashima78/ts-md-tsc": "workspace:*",
-    "commander": "catalog:",
-    "fast-glob": "catalog:",
     "tsx": "catalog:"
+  },
+  "engines": {
+    "node": ">=24"
   },
   "devDependencies": {
     "@sterashima78/ts-md-unplugin": "catalog:",

--- a/packages/cli/src/index.ts.md
+++ b/packages/cli/src/index.ts.md
@@ -2,62 +2,168 @@
 
 CLI entrypoint は domain logic を実装せず、command line の形を各 command function へ対応付けます。型検査、tangle、実行の詳細は別 document に置き、この file では利用者が見る command surface と process の終了方法だけを決めます。
 
-## Registering commands
+## Describing parsed commands
 
-`createCli` を関数として公開することで、実際に `process.argv` を parse せずに command 構成を test や他の entrypoint から再利用できます。
+Node.js 標準の `parseArgs` を使い、process を起動せず検証できる command model に変換します。`check` と `run` の後続引数は下位 tool に渡すため、解釈せず元の順序を保ちます。CLI 自身が所有する `tangle` の option だけを厳密に検証します。
 
-`check` と `run` は下位 tool へ未知の option を渡す必要があるため `allowUnknownOption` を使います。`tangle` は CLI 自身が `outDir` を解釈します。
+```ts parseCliArgs
+import { parseArgs } from 'node:util';
 
-```ts createCli
-import { Command } from 'commander';
-import { runCheck } from './commands/check.ts.md';
-import { runTsMd } from './commands/run.ts.md';
-import { runTangle } from './commands/tangle.ts.md';
+export type CliInvocation =
+  | { command: 'help'; subject?: 'check' | 'run' | 'tangle' }
+  | { command: 'check'; args: string[] }
+  | { command: 'run'; entry: string; args: string[] }
+  | { command: 'tangle'; globs: string[]; outDir: string };
 
-export function createCli() {
-  const program = new Command('tsmd');
+export function parseCliArgs(args: string[]): CliInvocation {
+  const topLevel = parseArgs({
+    args,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: true,
+    strict: false,
+  });
+  const command = args[0];
 
-  program
-    .command('check [tscArgs...]')
-    .allowUnknownOption()
-    .description('Type-check a tsconfig project without emitting files')
-    .action((tscArgs: string[]) => {
-      process.exitCode = runCheck(tscArgs);
-    });
+  if (!command || command === '--help' || command === '-h') {
+    return { command: 'help' };
+  }
+  if (command !== 'check' && command !== 'run' && command !== 'tangle') {
+    throw new TypeError(`Unknown command: ${command}`);
+  }
 
-  program
-    .command('tangle [globs...]')
-    .option('-o, --outDir <dir>', 'output directory', 'dist')
-    .description('Write each .ts.md module to a TypeScript file')
-    .action((globs: string[], options: { outDir: string }) =>
-      runTangle(globs, options.outDir),
-    );
+  const rest = args.slice(1);
+  if (topLevel.values.help) {
+    return {
+      command: 'help',
+      subject: command,
+    };
+  }
 
-  program
-    .command('run <entry>')
-    .allowUnknownOption()
-    .description('Execute a .ts.md main or named module')
-    .action((entry: string, _options: unknown, command: Command) => {
-      const rest =
-        command.parent?.args.slice(command.parent.args.indexOf('run') + 2) ?? [];
-      runTsMd(entry, rest);
-    });
+  if (command === 'check') return { command, args: rest };
 
-  return program;
+  if (command === 'run') {
+    const [entry, ...nodeArgs] = rest;
+    if (!entry) throw new TypeError('The run command requires an entry');
+    return { command, entry, args: nodeArgs };
+  }
+
+  const tangle = parseArgs({
+    args: rest,
+    options: {
+      outDir: { type: 'string', short: 'o', default: 'dist' },
+    },
+    allowPositionals: true,
+    strict: true,
+  });
+  return {
+    command,
+    globs: tangle.positionals,
+    outDir: tangle.values.outDir,
+  };
 }
 ```
 
-`run` の entry より後ろにある引数は Node.js で実行される module へ渡すため、Commander の parsed option として消費せず元の引数列から切り出します。
+## Dispatching commands
+
+help text も小さな data として保持し、外部 framework の暗黙的な出力に依存しません。`runCli` は parse 結果を対応する command function へ渡し、終了 status が必要な `check` だけ `process.exitCode` を更新します。
+
+```ts runCli
+import { runCheck } from './commands/check.ts.md';
+import { runTsMd } from './commands/run.ts.md';
+import { runTangle } from './commands/tangle.ts.md';
+import { parseCliArgs } from ':parseCliArgs';
+
+const help = {
+  root: `Usage: tsmd <command> [options]
+
+Commands:
+  check [...tscArgs]              Type-check a tsconfig project
+  run <entry> [...nodeArgs]       Execute a .ts.md module
+  tangle [globs...] [options]     Write modules as TypeScript files`,
+  check: 'Usage: tsmd check [...tscArgs]',
+  run: 'Usage: tsmd run <entry> [...nodeArgs]',
+  tangle: `Usage: tsmd tangle [globs...] [options]
+
+Options:
+  -o, --outDir <dir>              Output directory (default: dist)`,
+};
+
+export async function runCli(args = process.argv.slice(2)) {
+  const invocation = parseCliArgs(args);
+
+  if (invocation.command === 'help') {
+    console.log(invocation.subject ? help[invocation.subject] : help.root);
+    return;
+  }
+  if (invocation.command === 'check') {
+    process.exitCode = runCheck(invocation.args);
+    return;
+  }
+  if (invocation.command === 'run') {
+    await runTsMd(invocation.entry, invocation.args);
+    return;
+  }
+  await runTangle(invocation.globs, invocation.outDir);
+}
+```
 
 ## Executable module
 
-`main` module は package の executable entry です。構成関数を再公開した後、現在の process arguments を parse します。shebang をこの小さな module に閉じ込めることで、command 定義自体は通常の TypeScript function として扱えます。
+`main` module は package の executable entry です。parse error は stack trace ではなく簡潔な message として表示し、失敗 status を設定します。
 
 ```ts main
 #!/usr/bin/env node
-import { createCli } from ':createCli';
+import { runCli } from ':runCli';
 
-export { createCli };
+export { parseCliArgs } from ':parseCliArgs';
+export { runCli };
 
-createCli().parse();
+try {
+  await runCli();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}
+
+if (import.meta.vitest) {
+  await import(':parseCliArgs.test');
+}
+```
+
+## Executable examples of argument parsing
+
+下位 tool へ渡す option の順序と、CLI が所有する option の解釈を固定します。
+
+```ts parseCliArgs.test
+import { describe, expect, it } from 'vitest';
+import { parseCliArgs } from ':parseCliArgs';
+
+describe('parseCliArgs', () => {
+  it('preserves compiler arguments', () => {
+    expect(parseCliArgs(['check', '-p', 'tsconfig.json'])).toEqual({
+      command: 'check',
+      args: ['-p', 'tsconfig.json'],
+    });
+  });
+
+  it('separates the run entry from module arguments', () => {
+    expect(parseCliArgs(['run', 'app.ts.md', '--answer', '42'])).toEqual({
+      command: 'run',
+      entry: 'app.ts.md',
+      args: ['--answer', '42'],
+    });
+  });
+
+  it('parses tangle options and globs', () => {
+    expect(
+      parseCliArgs(['tangle', 'src/**/*.ts.md', '--outDir', 'generated']),
+    ).toEqual({
+      command: 'tangle',
+      globs: ['src/**/*.ts.md'],
+      outDir: 'generated',
+    });
+  });
+});
 ```

--- a/packages/cli/src/utils/globs.ts.md
+++ b/packages/cli/src/utils/globs.ts.md
@@ -7,10 +7,14 @@ pattern が省略された場合は current working directory 以下のすべて
 ## From patterns to files
 
 ```ts expandGlobs
-import fg from 'fast-glob';
+import { glob } from 'node:fs/promises';
+import path from 'node:path';
 
 export async function expandGlobs(globs: string[]): Promise<string[]> {
-  return fg(globs.length ? globs : ['**/*.ts.md'], { absolute: true });
+  const entries = await Array.fromAsync(
+    glob(globs.length ? globs : ['**/*.ts.md']),
+  );
+  return entries.map((entry) => path.resolve(entry));
 }
 ```
 
@@ -40,6 +44,25 @@ describe('expandGlobs', () => {
     await fs.writeFile(file, '', 'utf8');
     const files = await expandGlobs([`${tmp}/*.ts.md`]);
     expect(files).toEqual([file]);
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  it('expands multiple patterns', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'globs-'));
+    const first = path.join(tmp, 'first.ts.md');
+    const second = path.join(tmp, 'nested', 'second.ts.md');
+    await fs.mkdir(path.dirname(second));
+    await Promise.all([
+      fs.writeFile(first, '', 'utf8'),
+      fs.writeFile(second, '', 'utf8'),
+    ]);
+
+    const files = await expandGlobs([
+      `${tmp}/*.ts.md`,
+      `${tmp}/**/second.ts.md`,
+    ]);
+    expect(files).toHaveLength(2);
+    expect(files).toEqual(expect.arrayContaining([first, second]));
     await fs.rm(tmp, { recursive: true, force: true });
   });
 });

--- a/packages/cli/test/source-chunks.test.ts
+++ b/packages/cli/test/source-chunks.test.ts
@@ -1,3 +1,4 @@
+import '../src/index.ts.md:parseCliArgs.test';
 import '../src/commands/run.ts.md:runTsMd.test';
 import '../src/utils/globs.ts.md:expandGlobs.test';
 import '../src/utils/spawn.ts.md:spawnNode.test';

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: { index: 'src/index.ts.md' },
-  target: 'node18',
+  target: 'node24',
   format: ['esm'],
   shims: false,
   clean: true,
@@ -11,8 +11,6 @@ export default defineConfig({
   outExtensions: () => ({ js: '.js' }),
   deps: {
     neverBundle: [
-      'commander',
-      'fast-glob',
       '@sterashima78/ts-md-tsc',
       '@sterashima78/ts-md-core',
       '@sterashima78/ts-md-loader',

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,6 @@
     "@volar/language-service": "catalog:",
     "@volar/monaco": "catalog:",
     "astro": "catalog:",
-    "fast-glob": "catalog:",
     "monaco-editor": "catalog:",
     "sharp": "catalog:",
     "typescript": "catalog:",

--- a/packages/docs/src/packagesLoader.ts
+++ b/packages/docs/src/packagesLoader.ts
@@ -1,8 +1,7 @@
-import { promises as fs } from 'node:fs';
+import { glob, readFile } from 'node:fs/promises';
 import { dirname, join, normalize, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Loader } from 'astro/loaders';
-import fg from 'fast-glob';
 
 export function packagesLoader(): Loader {
   const root = new URL('../../..', import.meta.url);
@@ -13,10 +12,10 @@ export function packagesLoader(): Loader {
     name: 'packages-loader',
     async load(ctx) {
       const cwd = fileURLToPath(root);
-      const files = await fg(pattern, { cwd });
+      const files = await Array.fromAsync(glob(pattern, { cwd }));
       for (const entry of files) {
         const absPath = join(cwd, entry);
-        let body = await fs.readFile(absPath, 'utf8');
+        let body = await readFile(absPath, 'utf8');
         body = rewriteLinks(body, entry);
         let title: string | undefined;
         const heading = body.match(/^#\s+(.+?)(?:\r?\n|$)/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,12 +75,6 @@ catalogs:
     astro:
       specifier: 7.1.6
       version: 7.1.6
-    commander:
-      specifier: 15.0.0
-      version: 15.0.0
-    fast-glob:
-      specifier: 3.3.3
-      version: 3.3.3
     jsdom:
       specifier: 30.0.1
       version: 30.0.1
@@ -185,12 +179,6 @@ importers:
       '@sterashima78/ts-md-tsc':
         specifier: workspace:*
         version: link:../tsc
-      commander:
-        specifier: 'catalog:'
-        version: 15.0.0
-      fast-glob:
-        specifier: 'catalog:'
-        version: 3.3.3
       tsx:
         specifier: 'catalog:'
         version: 4.23.1
@@ -238,9 +226,6 @@ importers:
       astro:
         specifier: 'catalog:'
         version: 7.1.6(@astrojs/markdown-remark@7.2.2(supports-color@7.2.0))(@azure/identity@4.13.1(supports-color@7.2.0))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(rollup@4.62.3)(tsx@4.23.1)
-      fast-glob:
-        specifier: 'catalog:'
-        version: 3.3.3
       monaco-editor:
         specifier: 'catalog:'
         version: 0.56.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - packages/*
+cleanupUnusedCatalogs: true
 catalog:
   '@astrojs/starlight': 0.41.5
   '@biomejs/biome': 2.5.6
@@ -24,13 +25,10 @@ catalog:
   '@vscode/test-electron': 3.1.0
   '@vscode/vsce': 3.9.2
   astro: 7.1.6
-  commander: 15.0.0
-  fast-glob: 3.3.3
   jsdom: 30.0.1
   monaco-editor: 0.56.0
   react: 19.2.8
   react-dom: 19.2.8
-  remark-parse: 11.0.0
   rollup: 4.62.3
   satteri: 0.9.5
   sharp: 0.35.3
@@ -40,8 +38,6 @@ catalog:
   tsx: 4.23.1
   turbo: 2.10.7
   typescript: 6.0.3
-  unified: 11.0.5
-  unist-util-visit: 5.1.0
   unplugin: 3.3.0
   vite: 8.2.0
   vitest: 4.1.10


### PR DESCRIPTION
## 概要

- pnpm の `cleanupUnusedCatalogs` を有効化し、未使用 catalog エントリを削除
- `fast-glob` を Node.js 標準の `node:fs/promises` `glob` に置換
- `commander` を Node.js 標準の `node:util` `parseArgs` に置換
- Node.js 24 を実行・ビルド要件として明示
- CLI の引数解析と複数 glob パターンを検証するテストを追加
- CLI の minor changeset を追加

## 背景

標準APIで代替できる外部依存を削減し、pnpm catalog に未参照エントリが残らない状態を継続的に保つための変更です。

## 影響

CLI の `check` と `run` は後続引数を従来どおり転送し、`tangle` は `parseArgs` で `--outDir` を解釈します。Node.js の最低要件は24になります。

## 確認

- Biome: 成功
- catalog監査: 41項目すべて参照済み
- docs型検査: 成功
- docsテスト: 2件成功
- docs本番ビルド: 成功
- Node標準CLI/glob挙動テスト: 成功
- 全体テスト: GitHub Packages の認証情報がないため、セルフホスト依存の取得時に401となり未完了
