### PR TITLE
docs: include every TS-MD implementation package

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -6,7 +6,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "test": "vitest run src/workers/ts-md-language.test.ts"
+    "test": "vitest run"
   },
   "dependencies": {
     "@astrojs/starlight": "catalog:",

--- a/packages/docs/src/packagesLoader.test.ts
+++ b/packages/docs/src/packagesLoader.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addModuleTitles,
+  selectPackageDocumentEntries,
+} from './packagesLoader';
+
+describe('packagesLoader', () => {
+  it('TS-MD 実装を持つパッケージとその README を対象にする', () => {
+    const sourceEntries = [
+      'packages/vscode/src/commands.ts.md',
+      'packages/cli/src/index.ts.md',
+      'packages/monaco/src/browser/index.ts.md',
+    ];
+    const readmeEntries = [
+      'packages/docs/README.md',
+      'packages/monaco/README.md',
+      'packages/vscode/README.md',
+      'packages/cli/README.md',
+    ];
+
+    expect(
+      selectPackageDocumentEntries(sourceEntries, readmeEntries),
+    ).toEqual([
+      'packages/cli/README.md',
+      'packages/cli/src/index.ts.md',
+      'packages/monaco/README.md',
+      'packages/monaco/src/browser/index.ts.md',
+      'packages/vscode/README.md',
+      'packages/vscode/src/commands.ts.md',
+    ]);
+  });
+
+  it('TS-MD のモジュール名を Starlight のコードブロックタイトルにする', () => {
+    const markdown = [
+      '```ts split',
+      "export const value = 'split';",
+      '```',
+      '',
+      '~~~tsx component-name',
+      'export const Component = () => null;',
+      '~~~',
+    ].join('\n');
+
+    expect(addModuleTitles(markdown)).toBe(
+      [
+        '```ts title="split"',
+        "export const value = 'split';",
+        '```',
+        '',
+        '~~~tsx title="component-name"',
+        'export const Component = () => null;',
+        '~~~',
+      ].join('\n'),
+    );
+  });
+
+  it('Markdown の例示用フェンス内は書き換えない', () => {
+    const markdown = [
+      '````markdown',
+      '```ts example',
+      'export const example = true;',
+      '```',
+      '````',
+      '',
+      '```js example',
+      'export const javascript = true;',
+      '```',
+    ].join('\n');
+
+    expect(addModuleTitles(markdown)).toBe(markdown);
+  });
+});

--- a/packages/docs/src/packagesLoader.test.ts
+++ b/packages/docs/src/packagesLoader.test.ts
@@ -52,6 +52,23 @@ describe('packagesLoader', () => {
     ]);
   });
 
+  it('E2E テストフィクスチャとそのパッケージ README は対象にしない', () => {
+    const sourceEntries = [
+      'packages/core/src/index.ts.md',
+      'packages/e2e/src/fixtures/error-project/bad.ts.md',
+      'packages/e2e/src/fixtures/error-project/completion.ts.md',
+    ];
+    const readmeEntries = [
+      'packages/core/README.md',
+      'packages/e2e/README.md',
+    ];
+
+    expect(selectPackageDocumentEntries(sourceEntries, readmeEntries)).toEqual([
+      'packages/core/README.md',
+      'packages/core/src/index.ts.md',
+    ]);
+  });
+
   it('TS-MD のモジュール名を Starlight のコードブロックタイトルにする', () => {
     const markdown = [
       '```ts split',

--- a/packages/docs/src/packagesLoader.test.ts
+++ b/packages/docs/src/packagesLoader.test.ts
@@ -30,9 +30,7 @@ describe('packagesLoader', () => {
       'packages/cli/README.md',
     ];
 
-    expect(
-      selectPackageDocumentEntries(sourceEntries, readmeEntries),
-    ).toEqual([
+    expect(selectPackageDocumentEntries(sourceEntries, readmeEntries)).toEqual([
       'packages/cli/README.md',
       'packages/cli/src/index.ts.md',
       'packages/core/README.md',

--- a/packages/docs/src/packagesLoader.test.ts
+++ b/packages/docs/src/packagesLoader.test.ts
@@ -58,10 +58,7 @@ describe('packagesLoader', () => {
       'packages/e2e/src/fixtures/error-project/bad.ts.md',
       'packages/e2e/src/fixtures/error-project/completion.ts.md',
     ];
-    const readmeEntries = [
-      'packages/core/README.md',
-      'packages/e2e/README.md',
-    ];
+    const readmeEntries = ['packages/core/README.md', 'packages/e2e/README.md'];
 
     expect(selectPackageDocumentEntries(sourceEntries, readmeEntries)).toEqual([
       'packages/core/README.md',

--- a/packages/docs/src/packagesLoader.test.ts
+++ b/packages/docs/src/packagesLoader.test.ts
@@ -5,16 +5,28 @@ import {
 } from './packagesLoader';
 
 describe('packagesLoader', () => {
-  it('TS-MD 実装を持つパッケージとその README を対象にする', () => {
+  it('TS-MD 実装を持つすべてのパッケージとその README を対象にする', () => {
     const sourceEntries = [
       'packages/vscode/src/commands.ts.md',
-      'packages/cli/src/index.ts.md',
+      'packages/unplugin/src/index.ts.md',
+      'packages/tsc/src/compiler.ts.md',
+      'packages/sandbox/src/mini-core/graph.ts.md',
       'packages/monaco/src/browser/index.ts.md',
+      'packages/ls-core/src/plugin.ts.md',
+      'packages/loader/src/index.ts.md',
+      'packages/core/src/graph.ts.md',
+      'packages/cli/src/index.ts.md',
     ];
     const readmeEntries = [
       'packages/docs/README.md',
-      'packages/monaco/README.md',
       'packages/vscode/README.md',
+      'packages/unplugin/README.md',
+      'packages/tsc/README.md',
+      'packages/sandbox/README.md',
+      'packages/monaco/README.md',
+      'packages/ls-core/README.md',
+      'packages/loader/README.md',
+      'packages/core/README.md',
       'packages/cli/README.md',
     ];
 
@@ -23,8 +35,20 @@ describe('packagesLoader', () => {
     ).toEqual([
       'packages/cli/README.md',
       'packages/cli/src/index.ts.md',
+      'packages/core/README.md',
+      'packages/core/src/graph.ts.md',
+      'packages/loader/README.md',
+      'packages/loader/src/index.ts.md',
+      'packages/ls-core/README.md',
+      'packages/ls-core/src/plugin.ts.md',
       'packages/monaco/README.md',
       'packages/monaco/src/browser/index.ts.md',
+      'packages/sandbox/README.md',
+      'packages/sandbox/src/mini-core/graph.ts.md',
+      'packages/tsc/README.md',
+      'packages/tsc/src/compiler.ts.md',
+      'packages/unplugin/README.md',
+      'packages/unplugin/src/index.ts.md',
       'packages/vscode/README.md',
       'packages/vscode/src/commands.ts.md',
     ]);

--- a/packages/docs/src/packagesLoader.ts
+++ b/packages/docs/src/packagesLoader.ts
@@ -3,20 +3,34 @@ import { dirname, join, normalize, posix } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Loader } from 'astro/loaders';
 
+const TS_MD_SOURCE_PATTERN = 'packages/*/src/**/*.ts.md';
+const PACKAGE_README_PATTERN = 'packages/*/README.md';
+const PACKAGE_ENTRY_PATTERN = /^packages\/([^/]+)\//;
+const MODULE_INFO_PATTERN = /^(ts|tsx)\s+([a-zA-Z0-9._-]+)$/;
+
 export function packagesLoader(): Loader {
   const root = new URL('../../..', import.meta.url);
-  const pattern =
-    'packages/{cli,core,loader,ls-core,unplugin}/{README.md,src/**/*.ts.md}';
 
   return {
     name: 'packages-loader',
     async load(ctx) {
       const cwd = fileURLToPath(root);
-      const files = await Array.fromAsync(glob(pattern, { cwd }));
+      const sourceEntries = await Array.fromAsync(
+        glob(TS_MD_SOURCE_PATTERN, { cwd }),
+      );
+      const readmeEntries = await Array.fromAsync(
+        glob(PACKAGE_README_PATTERN, { cwd }),
+      );
+      const files = selectPackageDocumentEntries(
+        sourceEntries,
+        readmeEntries,
+      );
+
       for (const entry of files) {
         const absPath = join(cwd, entry);
         let body = await readFile(absPath, 'utf8');
         body = rewriteLinks(body, entry);
+        body = addModuleTitles(body);
         let title: string | undefined;
         const heading = body.match(/^#\s+(.+?)(?:\r?\n|$)/);
         if (heading) {
@@ -52,6 +66,53 @@ export function packagesLoader(): Loader {
       }
     },
   };
+}
+
+export function selectPackageDocumentEntries(
+  sourceEntries: readonly string[],
+  readmeEntries: readonly string[],
+): string[] {
+  const packageNames = new Set<string>();
+  for (const entry of sourceEntries) {
+    const packageName = entry.match(PACKAGE_ENTRY_PATTERN)?.[1];
+    if (packageName) packageNames.add(packageName);
+  }
+
+  return [
+    ...sourceEntries,
+    ...readmeEntries.filter((entry) => {
+      const packageName = entry.match(PACKAGE_ENTRY_PATTERN)?.[1];
+      return packageName !== undefined && packageNames.has(packageName);
+    }),
+  ].sort();
+}
+
+export function addModuleTitles(markdown: string): string {
+  let openFence: { marker: string; length: number } | undefined;
+
+  return markdown.replace(/^.*$/gm, (line) => {
+    const match = line.match(/^(\s*)(`{3,}|~{3,})(.*)$/);
+    if (!match) return line;
+
+    const [, indentation, fence, rawInfo] = match;
+    if (openFence) {
+      if (
+        fence[0] === openFence.marker &&
+        fence.length >= openFence.length &&
+        rawInfo.trim() === ''
+      ) {
+        openFence = undefined;
+      }
+      return line;
+    }
+
+    openFence = { marker: fence[0], length: fence.length };
+    const moduleInfo = rawInfo.trim().match(MODULE_INFO_PATTERN);
+    if (!moduleInfo) return line;
+
+    const [, language, moduleName] = moduleInfo;
+    return `${indentation}${fence}${language} title="${moduleName}"`;
+  });
 }
 
 function rewriteLinks(md: string, entry: string): string {

--- a/packages/docs/src/packagesLoader.ts
+++ b/packages/docs/src/packagesLoader.ts
@@ -6,6 +6,7 @@ import type { Loader } from 'astro/loaders';
 const TS_MD_SOURCE_PATTERN = 'packages/*/src/**/*.ts.md';
 const PACKAGE_README_PATTERN = 'packages/*/README.md';
 const PACKAGE_ENTRY_PATTERN = /^packages\/([^/]+)\//;
+const PACKAGE_FIXTURE_PATTERN = /^packages\/[^/]+\/src\/fixtures\//;
 const MODULE_INFO_PATTERN = /^(ts|tsx)\s+([a-zA-Z0-9._-]+)$/;
 
 export function packagesLoader(): Loader {
@@ -69,14 +70,17 @@ export function selectPackageDocumentEntries(
   sourceEntries: readonly string[],
   readmeEntries: readonly string[],
 ): string[] {
+  const implementationEntries = sourceEntries.filter(
+    (entry) => !PACKAGE_FIXTURE_PATTERN.test(entry),
+  );
   const packageNames = new Set<string>();
-  for (const entry of sourceEntries) {
+  for (const entry of implementationEntries) {
     const packageName = entry.match(PACKAGE_ENTRY_PATTERN)?.[1];
     if (packageName) packageNames.add(packageName);
   }
 
   return [
-    ...sourceEntries,
+    ...implementationEntries,
     ...readmeEntries.filter((entry) => {
       const packageName = entry.match(PACKAGE_ENTRY_PATTERN)?.[1];
       return packageName !== undefined && packageNames.has(packageName);

--- a/packages/docs/src/packagesLoader.ts
+++ b/packages/docs/src/packagesLoader.ts
@@ -94,10 +94,14 @@ export function addModuleTitles(markdown: string): string {
     const match = line.match(/^(\s*)(`{3,}|~{3,})(.*)$/);
     if (!match) return line;
 
-    const [, indentation, fence, rawInfo] = match;
+    const indentation = match[1] ?? '';
+    const fence = match[2];
+    const rawInfo = match[3] ?? '';
+    if (!fence) return line;
+
     if (openFence) {
       if (
-        fence[0] === openFence.marker &&
+        fence.charAt(0) === openFence.marker &&
         fence.length >= openFence.length &&
         rawInfo.trim() === ''
       ) {
@@ -106,11 +110,12 @@ export function addModuleTitles(markdown: string): string {
       return line;
     }
 
-    openFence = { marker: fence[0], length: fence.length };
+    openFence = { marker: fence.charAt(0), length: fence.length };
     const moduleInfo = rawInfo.trim().match(MODULE_INFO_PATTERN);
-    if (!moduleInfo) return line;
+    const language = moduleInfo?.[1];
+    const moduleName = moduleInfo?.[2];
+    if (!language || !moduleName) return line;
 
-    const [, language, moduleName] = moduleInfo;
     return `${indentation}${fence}${language} title="${moduleName}"`;
   });
 }

--- a/packages/docs/src/packagesLoader.ts
+++ b/packages/docs/src/packagesLoader.ts
@@ -21,10 +21,7 @@ export function packagesLoader(): Loader {
       const readmeEntries = await Array.fromAsync(
         glob(PACKAGE_README_PATTERN, { cwd }),
       );
-      const files = selectPackageDocumentEntries(
-        sourceEntries,
-        readmeEntries,
-      );
+      const files = selectPackageDocumentEntries(sourceEntries, readmeEntries);
 
       for (const entry of files) {
         const absPath = join(cwd, entry);


### PR DESCRIPTION
## 変更内容

- ドキュメント対象のパッケージ一覧をハードコードせず、`packages/*/src/**/*.ts.md` から自動検出するように変更
- TS-MD 実装を持つパッケージについて README もドキュメントへ追加
- TS-MD コードフェンスのモジュール名を Starlight の `title="moduleName"` へ表示時に変換
- パッケージ選択、コードブロックタイトル、入れ子の例示用フェンスを対象としたテストを追加
- docs パッケージのテストスクリプトを全テスト実行へ変更

これにより、現在ドキュメントから漏れている `monaco`、`sandbox`、`tsc`、`vscode` を含め、今後追加される TS-MD 実装パッケージも自動的に対象になります。

## 確認

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`

GitHub Actions で上記がすべて成功しています。